### PR TITLE
Improved typedef of MessageAttributes to ease usage

### DIFF
--- a/packages/bus-core/src/bus-module.ts
+++ b/packages/bus-core/src/bus-module.ts
@@ -1,7 +1,7 @@
 import { ContainerModule, interfaces } from 'inversify'
 import { BUS_SYMBOLS, BUS_INTERNAL_SYMBOLS } from './bus-symbols'
 import { MemoryQueue } from './transport'
-import { ServiceBus } from './service-bus'
+import { ServiceBus, MessageAttributes } from './service-bus'
 import { JsonSerializer } from './serialization'
 import { ApplicationBootstrap } from './application-bootstrap'
 import { HandlerRegistry } from './handler'
@@ -27,7 +27,7 @@ export class BusModule extends ContainerModule {
       bindService(bind, BUS_SYMBOLS.HandlerRegistry, HandlerRegistry).inSingletonScope()
       bindService(bind, BUS_SYMBOLS.JsonSerializer, JsonSerializer)
 
-      bind(BUS_SYMBOLS.MessageHandlingContext).toConstantValue({})
+      bind(BUS_SYMBOLS.MessageHandlingContext).toConstantValue(new MessageAttributes())
     })
   }
 }

--- a/packages/bus-core/src/service-bus/message-attributes.ts
+++ b/packages/bus-core/src/service-bus/message-attributes.ts
@@ -29,7 +29,7 @@ export class MessageAttributes<
    * These attributes will be attached to the outgoing message, but will not
    * propagate beyond the first receipt
    */
-  attributes?: AttributeType
+  attributes: AttributeType = {} as AttributeType
 
   /**
    * Additional metadata that will be sent alongside the message payload.
@@ -39,5 +39,5 @@ export class MessageAttributes<
    * These values are sticky, in that they will propagate for any message that
    * is sent as a result of receiving the message with sticky attributes.
    */
-  stickyAttributes?: StickyAttributeType
+  stickyAttributes: StickyAttributeType = {} as StickyAttributeType
 }


### PR DESCRIPTION
In the past, user would have to speculate whether `attributes` and `stickyAttributes` are undefined. 
This PR fixes this