### PR TITLE
Make bus-postgres compatible with PG 9.4 when creating index

### DIFF
--- a/packages/bus-postgres/src/postgres-persistence.integration.ts
+++ b/packages/bus-postgres/src/postgres-persistence.integration.ts
@@ -1,4 +1,5 @@
-import { Bus, ApplicationBootstrap, BUS_SYMBOLS, MessageAttributes } from '@node-ts/bus-core'
+import { Bus, ApplicationBootstrap, BUS_SYMBOLS } from '@node-ts/bus-core'
+import { MessageAttributes } from '@node-ts/bus-messages'
 import { PostgresPersistence } from './postgres-persistence'
 import { TestContainer, TestWorkflow, TestWorkflowData, TestCommand } from '../test'
 import { BUS_WORKFLOW_SYMBOLS, WorkflowRegistry, MessageWorkflowMapping, WorkflowStatus } from '@node-ts/bus-workflow'

--- a/packages/bus-postgres/src/postgres-persistence.ts
+++ b/packages/bus-postgres/src/postgres-persistence.ts
@@ -140,14 +140,23 @@ export class PostgresPersistence implements Persistence {
 
     const createSecondaryIndexes = workflowFields.map(async workflowField => {
       const indexName = resolveIndexName(tableName, workflowField)
+      const indexNameWithSchema = `${this.configuration.schemaName}.${indexName}`
       const workflowDataField = `${WORKFLOW_DATA_FIELD_NAME}->>'${workflowField}'`
+      // Support Postgres 9.4+
       const createSecondaryIndex = `
-        create index if not exists
-          ${indexName}
-        on
-          ${tableName} ((${workflowDataField}))
-        where
-          (${workflowDataField}) is not null;
+        DO
+        $$
+        BEGIN
+          IF to_regclass('${indexNameWithSchema}') IS NULL THEN
+            CREATE INDEX
+              ${indexName}
+            ON
+              ${tableName} ((${workflowDataField}))
+            WHERE
+              (${workflowDataField}) is not null;
+          END IF;
+        END
+        $$;
       `
       this.logger.debug('Ensuring secondary index exists', { createSecondaryIndex })
       await this.postgres.query(createSecondaryIndex)
@@ -158,7 +167,18 @@ export class PostgresPersistence implements Persistence {
 
   private async createPrimaryIndex (tableName: string): Promise<void> {
     const primaryIndexName = resolveIndexName(tableName, 'id', 'version')
-    const createPrimaryIndexSql = `create index if not exists ${primaryIndexName} on ${tableName} (id, version);`
+    const primaryIndexNameWithSchema = `${this.configuration.schemaName}.${primaryIndexName}`
+    // Support Postgres 9.4+
+    const createPrimaryIndexSql = `
+      DO
+      $$
+      BEGIN
+        IF to_regclass('${primaryIndexNameWithSchema}') IS NULL THEN
+          CREATE INDEX ${primaryIndexName} ON ${tableName} (id, version);
+        END IF;
+      END
+      $$;
+    `
     this.logger.debug('Ensuring primary index exists', { createPrimaryIndexSql })
     await this.postgres.query(createPrimaryIndexSql)
   }


### PR DESCRIPTION
PostgreSQL 9.4 does not support `create index XX if not exist`

This PR uses older syntax for this feature so bus-postgres can work with PG 9.4.

I have ran the test for bus-postgres manually and it was successful. 

<img width="847" alt="Screen Shot 2019-07-10 at 16 35 12" src="https://user-images.githubusercontent.com/1054703/60946121-b744ae00-a330-11e9-8cb8-3b7ad46b049a.png">
