### PR TITLE
Fix failing tests

### DIFF
--- a/packages/bus-core/src/handler/handler.integration.ts
+++ b/packages/bus-core/src/handler/handler.integration.ts
@@ -1,5 +1,6 @@
 import { TestEvent } from '../test/test-event'
-import { Bus, MessageAttributes } from '../service-bus'
+import { Bus } from '../service-bus'
+import { MessageAttributes } from '@node-ts/bus-messages'
 import { TestCommand } from '../test/test-command'
 import { Container } from 'inversify'
 import { BUS_SYMBOLS } from '../bus-symbols'

--- a/packages/bus-core/src/transport/memory-queue.spec.ts
+++ b/packages/bus-core/src/transport/memory-queue.spec.ts
@@ -14,9 +14,9 @@ const command2 = new TestCommand2()
 describe('MemoryQueue', () => {
   let sut: MemoryQueue
   const handledMessageNames = [TestCommand.NAME, TestEvent.NAME]
-  const messageOptions: MessageAttributes = {
+  const messageOptions = new MessageAttributes({
     correlationId: faker.random.uuid()
-  }
+   })
 
   beforeEach(async () => {
     sut = new MemoryQueue(
@@ -72,7 +72,7 @@ describe('MemoryQueue', () => {
 
     it('should return the oldest message when there are many', async () => {
       await sut.publish(event, messageOptions)
-      await sut.send(command, {})
+      await sut.send(command)
 
       const firstMessage = await sut.readNextMessage()
       expect(firstMessage!.domainMessage).toEqual(event)

--- a/packages/bus-core/src/transport/memory-queue.ts
+++ b/packages/bus-core/src/transport/memory-queue.ts
@@ -55,11 +55,11 @@ export class MemoryQueue implements Transport<InMemoryMessage> {
     }
   }
 
-  async publish<TEvent extends Event> (event: TEvent, messageOptions: MessageAttributes): Promise<void> {
+  async publish<TEvent extends Event> (event: TEvent, messageOptions?: MessageAttributes): Promise<void> {
     this.addToQueue(event, messageOptions)
   }
 
-  async send<TCommand extends Command> (command: TCommand, messageOptions: MessageAttributes): Promise<void> {
+  async send<TCommand extends Command> (command: TCommand, messageOptions?: MessageAttributes): Promise<void> {
     this.addToQueue(command, messageOptions)
   }
 
@@ -109,7 +109,7 @@ export class MemoryQueue implements Transport<InMemoryMessage> {
     await this.deleteMessage(message)
   }
 
-  private addToQueue (message: Message, messageOptions: MessageAttributes): void {
+  private addToQueue (message: Message, messageOptions: MessageAttributes = new MessageAttributes()): void {
     if (this.messagesWithHandlers[message.$name]) {
       const transportMessage = toTransportMessage(message, messageOptions, false)
       this.queue.push(transportMessage)

--- a/packages/bus-core/src/transport/transport.ts
+++ b/packages/bus-core/src/transport/transport.ts
@@ -13,7 +13,7 @@ export interface Transport<TransportMessageType = {}> {
    * @param messageOptions Options that control the behaviour around how the message is sent and
    * additional information that travels with it.
    */
-  publish<TEvent extends Event> (event: TEvent, messageOptions: MessageAttributes): Promise<void>
+  publish<TEvent extends Event> (event: TEvent, messageOptions?: MessageAttributes): Promise<void>
 
   /**
    * Sends a command to the underlying transport. This is generally done to a topic or some other
@@ -22,7 +22,7 @@ export interface Transport<TransportMessageType = {}> {
    * @param messageOptions Options that control the behaviour around how the message is sent and
    * additional information that travels with it.
    */
-  send<TCommand extends Command> (command: TCommand, messageOptions: MessageAttributes): Promise<void>
+  send<TCommand extends Command> (command: TCommand, messageOptions?: MessageAttributes): Promise<void>
 
   /**
    * Fetch the next message from the underlying queue. If there are no messages, then `undefined`

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
@@ -2,9 +2,10 @@ import { RabbitMqTransport } from './rabbitmq-transport'
 import { TestContainer, TestEvent, TestCommand, TestCommandHandler } from '../test'
 import { BUS_RABBITMQ_INTERNAL_SYMBOLS, BUS_RABBITMQ_SYMBOLS } from './bus-rabbitmq-symbols'
 import { Connection, Channel, Message as RabbitMqMessage } from 'amqplib'
-import { TransportMessage, BUS_SYMBOLS, ApplicationBootstrap, Bus, MessageAttributes } from '@node-ts/bus-core'
+import { TransportMessage, BUS_SYMBOLS, ApplicationBootstrap, Bus } from '@node-ts/bus-core'
 import { RabbitMqTransportConfiguration } from './rabbitmq-transport-configuration'
 import * as faker from 'faker'
+import { MessageAttributes } from '@node-ts/bus-messages'
 
 export async function sleep (timeoutMs: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeoutMs))
@@ -85,7 +86,7 @@ describe('RabbitMqTransport', () => {
       describe('from a queue with messages', () => {
         const command = new TestCommand()
         let message: TransportMessage<RabbitMqMessage> | undefined
-        const messageOptions: MessageAttributes = {
+        const messageOptions = new MessageAttributes({
           correlationId: faker.random.uuid(),
           attributes: {
             attribute1: 'a',
@@ -95,7 +96,7 @@ describe('RabbitMqTransport', () => {
             attribute1: 'b',
             attribute2: 2
           }
-        }
+        })
 
         beforeEach(async () => {
           await bus.send(command, messageOptions)
@@ -114,10 +115,10 @@ describe('RabbitMqTransport', () => {
         })
 
         it('should receive the message options', () => {
-          expect(message!.messageOptions).toBeDefined()
-          expect(message!.messageOptions.correlationId).toEqual(messageOptions.correlationId)
-          expect(message!.messageOptions.attributes).toMatchObject(messageOptions.attributes!)
-          expect(message!.messageOptions.stickyAttributes).toMatchObject(messageOptions.stickyAttributes!)
+          expect(message!.attributes).toBeDefined()
+          expect(message!.attributes.correlationId).toEqual(messageOptions.correlationId)
+          expect(message!.attributes.attributes).toMatchObject(messageOptions.attributes!)
+          expect(message!.attributes.stickyAttributes).toMatchObject(messageOptions.stickyAttributes!)
         })
 
         it('should should not ack the message from the queue', async () => {

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -41,12 +41,12 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     await this.connection.close()
   }
 
-  async publish<TEvent extends Event> (event: TEvent, messageAttriutes: MessageAttributes): Promise<void> {
-    await this.publishMessage(event, messageAttriutes)
+  async publish<TEvent extends Event> (event: TEvent, messageAttributes?: MessageAttributes): Promise<void> {
+    await this.publishMessage(event, messageAttributes)
   }
 
-  async send<TCommand extends Command> (command: TCommand, messageAttriutes: MessageAttributes): Promise<void> {
-    await this.publishMessage(command, messageAttriutes)
+  async send<TCommand extends Command> (command: TCommand, messageAttributes?: MessageAttributes): Promise<void> {
+    await this.publishMessage(command, messageAttributes)
   }
 
   async readNextMessage (): Promise<TransportMessage<RabbitMqMessage> | undefined> {
@@ -126,7 +126,10 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     await this.channel.bindQueue(deadLetterQueue, deadLetterExchange, '')
   }
 
-  private async publishMessage (message: Message, messageOptions: MessageAttributes): Promise<void> {
+  private async publishMessage (
+    message: Message,
+    messageOptions: MessageAttributes = new MessageAttributes()
+  ): Promise<void> {
     await this.assertExchange(message.$name)
     const payload = JSON.stringify(message)
     this.channel.publish(message.$name, '', Buffer.from(payload), {

--- a/packages/bus-sqs/src/sqs-transport.integration.ts
+++ b/packages/bus-sqs/src/sqs-transport.integration.ts
@@ -6,13 +6,14 @@ import {
   HandleChecker,
   HANDLE_CHECKER
 } from '../test'
-import { BUS_SYMBOLS, ApplicationBootstrap, Bus, sleep, MessageAttributes } from '@node-ts/bus-core'
+import { BUS_SYMBOLS, ApplicationBootstrap, Bus, sleep } from '@node-ts/bus-core'
 import { SQS, SNS } from 'aws-sdk'
 import { BUS_SQS_INTERNAL_SYMBOLS, BUS_SQS_SYMBOLS } from './bus-sqs-symbols'
 import { SqsTransportConfiguration } from './sqs-transport-configuration'
 import { IMock, Mock, Times, It } from 'typemoq'
 import * as uuid from 'uuid'
 import * as faker from 'faker'
+import { MessageAttributes } from '@node-ts/bus-messages'
 
 function getEnvVar (key: string): string {
   const value = process.env[key]

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -55,11 +55,11 @@ export class SqsTransport implements Transport<SQS.Message> {
   ) {
   }
 
-  async publish<EventType extends Event> (event: EventType, messageAttributes: MessageAttributes): Promise<void> {
+  async publish<EventType extends Event> (event: EventType, messageAttributes?: MessageAttributes): Promise<void> {
     await this.publishMessage(event, messageAttributes)
   }
 
-  async send<CommandType extends Command> (command: CommandType, messageAttributes: MessageAttributes): Promise<void> {
+  async send<CommandType extends Command> (command: CommandType, messageAttributes?: MessageAttributes): Promise<void> {
     await this.publishMessage(command, messageAttributes)
   }
 
@@ -204,7 +204,10 @@ export class SqsTransport implements Transport<SQS.Message> {
     }
   }
 
-  private async publishMessage (message: Message, messageAttributes: MessageAttributes): Promise<void> {
+  private async publishMessage (
+    message: Message,
+    messageAttributes: MessageAttributes = new MessageAttributes()
+  ): Promise<void> {
     await this.assertSnsTopic(message)
 
     const topicName = this.sqsConfiguration.resolveTopicName(message.$name)

--- a/packages/bus-sqs/test/test-command-handler.ts
+++ b/packages/bus-sqs/test/test-command-handler.ts
@@ -1,4 +1,5 @@
-import { HandlesMessage, MessageAttributes } from '@node-ts/bus-core'
+import { HandlesMessage } from '@node-ts/bus-core'
+import { MessageAttributes } from '@node-ts/bus-messages'
 import { TestCommand } from './test-command'
 import { inject } from 'inversify'
 

--- a/packages/bus-workflow/src/workflow/workflow.integration.ts
+++ b/packages/bus-workflow/src/workflow/workflow.integration.ts
@@ -1,5 +1,5 @@
 import { Container } from 'inversify'
-import { BusModule, Bus, BUS_SYMBOLS, ApplicationBootstrap, MessageAttributes } from '@node-ts/bus-core'
+import { BusModule, Bus, BUS_SYMBOLS, ApplicationBootstrap } from '@node-ts/bus-core'
 import { Persistence } from './persistence'
 import { BUS_WORKFLOW_SYMBOLS } from '../bus-workflow-symbols'
 import { TestCommand, TestWorkflowData, TestWorkflow, TaskRan, FinalTask } from '../test'
@@ -18,6 +18,7 @@ import {
   TestWorkflowStartedByDiscardData
 } from '../test/test-workflow-startedby-discard'
 import { Mock } from 'typemoq'
+import { MessageAttributes } from '@node-ts/bus-messages'
 
 describe('Workflow', () => {
   let container: Container
@@ -108,7 +109,7 @@ describe('Workflow', () => {
         beforeAll(async () => {
           await bus.publish(
             finalTask,
-            { correlationId: nextWorkflowData[0].$workflowId }
+            new MessageAttributes({ correlationId: nextWorkflowData[0].$workflowId })
           )
           await sleep(CONSUME_TIMEOUT)
 


### PR DESCRIPTION
A number of integration tests were failing to run due to movements of classes between packages.

These have been fixed, re-run and are now passing again. There were no failures in the tests themselves at any point.