### PR TITLE
Fix error handling for handlers

### DIFF
--- a/packages/bus-core/src/service-bus/service-bus.ts
+++ b/packages/bus-core/src/service-bus/service-bus.ts
@@ -158,5 +158,5 @@ async function dispatchMessageToHandler (
   sessionScopeBinder(childContainer.bind.bind(childContainer))
 
   const handler = handlerRegistration.resolveHandler(childContainer)
-  handler.handle(message, context)
+  return handler.handle(message, context)
 }


### PR DESCRIPTION
Hey there,

first of all: I really like the basics of the approach you're following, great job so far!

When trying to do a first example (one simple command, handled by a handler, emitting an event with a listener attached) I also wanted to test the bus' behavior in case a handler throws an error - basically when something goes wrong during processing. 
And this is what I found:

Since `ServiceBus:dispatchMessageToHandler` didn't return the Promise of `handler.handle(message, context)` `handlersToInvoke` in `ServiceBus:dispatchMessageToHandlers` contained an array of Promise<undefined> so a handler error never got to the catch block in `ServiceBus:handleNextMessage`, thus the message was always deleted from instead of returned to the transport in case of an error (super dangerous in production). Additionally it caused an `UnhandledPromiseRejectionWarning` which may crash the whole application as soon as nodejs decides to not handle that gracefully anymore.

Since the current testing setup is not really made to easily plug in a test for that I haven't provided a test for now (since it takes a bit longer) but I'm happy to do so afterwards.

Happy to answer any questions that may arise.

Cheers

