### PR TITLE
Provide topic identifier for system messages

### DIFF
--- a/packages/bus-core/src/application-bootstrap/application-bootstrap.spec.ts
+++ b/packages/bus-core/src/application-bootstrap/application-bootstrap.spec.ts
@@ -61,7 +61,8 @@ describe('ApplicationBootstrap', () => {
           It.isAny(),
           It.isAny(),
           TestCommandHandler,
-          TestCommand
+          TestCommand,
+          undefined
         ),
         Times.once()
       )

--- a/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
+++ b/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
@@ -68,7 +68,8 @@ export class ApplicationBootstrap {
       prototype.$resolver,
       prototype.$symbol,
       handler,
-      prototype.$message
+      prototype.$message,
+      prototype.$topicIdentifier
     )
   }
 }

--- a/packages/bus-core/src/handler/handler-registry.spec.ts
+++ b/packages/bus-core/src/handler/handler-registry.spec.ts
@@ -4,6 +4,7 @@ import { Logger } from '@node-ts/logger-core'
 import { TestEvent, TestEventHandler, TestCommandHandler, TestCommand } from '../test'
 import { Container, interfaces } from 'inversify'
 import { Message } from '@node-ts/bus-messages'
+import * as faker from 'faker'
 
 describe('HandlerRegistry', () => {
   let sut: HandlerRegistry
@@ -32,8 +33,8 @@ describe('HandlerRegistry', () => {
       expect(handlers).toHaveLength(1)
     })
 
-    it('should add it to the subscribed bus messages list', () => {
-      const subscription = sut.subscribedBusMessages.find(s => new s().$name === messageType.NAME)
+    it('should add it to the subscribed message subscription list', () => {
+      const subscription = sut.messageSubscriptions.find(s => new s.messageType!().$name === messageType.NAME)
       expect(subscription).toBeDefined()
     })
 
@@ -73,13 +74,15 @@ describe('HandlerRegistry', () => {
   })
 
   describe('when registering a handler for an external message', () => {
+    const identifier = faker.random.uuid()
+
     beforeEach(() => {
-      sut.register((m: Message) => m.$name === messageName, symbol, handler)
+      sut.register((m: Message) => m.$name === messageName, symbol, handler, undefined, identifier)
     })
 
-    it('should not include the message in the subscribed bus messages list', () => {
-      const messageSubscription = sut.subscribedBusMessages.find(m => new m().$name === messageName)
-      expect(messageSubscription).toBeUndefined()
+    it('should include the message in the subscribed messages list', () => {
+      const messageSubscription = sut.messageSubscriptions.find(m => m.topicIdentifier === identifier)
+      expect(messageSubscription).toBeDefined()
     })
   })
 

--- a/packages/bus-core/src/handler/handler-registry.ts
+++ b/packages/bus-core/src/handler/handler-registry.ts
@@ -17,20 +17,11 @@ interface HandlerBinding {
   handler: HandlerType
 }
 
-interface RegisteredHandlers {
-  messageType: ClassConstructor<Message>
-  handlers: HandlerBinding[]
-}
-
-interface HandlerRegistrations {
-  [key: string]: RegisteredHandlers
-}
-
-type MessageName = string
-
 interface HandlerResolver {
   handler: HandlerType
   symbol: symbol
+  topicIdentifier: string | undefined
+  messageType: ClassConstructor<Message> | undefined
   resolver (message: unknown): boolean
 }
 
@@ -42,9 +33,7 @@ interface HandlerResolver {
 export class HandlerRegistry {
 
   private container: Container
-  private unhandledMessages: MessageName[] = []
   private handlerResolvers: HandlerResolver[] = []
-  private registeredBusMessages: ClassConstructor<Message>[] = []
 
   constructor (
     @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger
@@ -57,12 +46,15 @@ export class HandlerRegistry {
    * @param symbol A unique symbol to identify the binding of the message to the function
    * @param handler The function handler to dispatch messages to as they arrive
    * @param messageType The class type of message to handle
+   * @param topicIdentifier Identifies the topic where the message is sourced from. This topic must exist
+   * before being consumed as the library assumes it's managed externally
    */
   register<TMessage extends MessageType = MessageType> (
     resolver: (message: TMessage) => boolean,
     symbol: symbol,
     handler: HandlerType,
-    messageType?: ClassConstructor<Message>
+    messageType?: ClassConstructor<Message>,
+    topicIdentifier?: string
   ): void {
 
     const handlerName = getHandlerName(handler)
@@ -84,10 +76,8 @@ export class HandlerRegistry {
       }
     }
 
-    this.handlerResolvers.push({ resolver, symbol, handler })
-    if (!!messageType) {
-      this.registeredBusMessages.push(messageType)
-    }
+    this.handlerResolvers.push({ messageType, resolver, symbol, handler, topicIdentifier })
+
     this.logger.info(
       'Handler registered',
       { messageName: messageType ? messageType.name : undefined, handler: handlerName }
@@ -151,8 +141,8 @@ export class HandlerRegistry {
   /**
    * Retrieves a list of all messages that have handler registrations
    */
-  get subscribedBusMessages (): ClassConstructor<Message>[] {
-    return this.registeredBusMessages
+  get messageSubscriptions (): HandlerResolver[] {
+    return this.handlerResolvers
   }
 
   private bindHandlers (): void {

--- a/packages/bus-core/src/handler/handler-registry.ts
+++ b/packages/bus-core/src/handler/handler-registry.ts
@@ -12,12 +12,7 @@ export interface HandlerRegistration<TMessage extends MessageType> {
   resolveHandler (handlerContextContainer: Container): Handler<TMessage>
 }
 
-interface HandlerBinding {
-  symbol: symbol
-  handler: HandlerType
-}
-
-interface HandlerResolver {
+export interface HandlerResolver {
   handler: HandlerType
   symbol: symbol
   topicIdentifier: string | undefined

--- a/packages/bus-core/src/handler/handler.ts
+++ b/packages/bus-core/src/handler/handler.ts
@@ -17,6 +17,16 @@ export interface HandlerPrototype<T extends MessageType> {
   $symbol: symbol
 
   /**
+   * An optional topic identifier where the source message is published to. This is used to
+   * subscribe the application queue to non-application type messages like infrastructure or
+   * third party messages.
+   *
+   * This field accepts identifiers of the transport used. eg. SQS transports will accept a
+   * source SNS arn, whereas a RabbitMQ transport would use a topic name.
+   */
+  $topicIdentifier: string | undefined
+
+  /**
    * The resolver to use that determines if a given message should be dispatched to the handler
    * it's attached to
    * @param message A message received from the underlying transport

--- a/packages/bus-core/src/handler/index.ts
+++ b/packages/bus-core/src/handler/index.ts
@@ -1,3 +1,3 @@
 export * from './handler-registry'
 export * from './handles-message'
-export { Handler } from './handler'
+export { Handler, MessageType } from './handler'

--- a/packages/bus-core/src/test/test-resolver-handler.ts
+++ b/packages/bus-core/src/test/test-resolver-handler.ts
@@ -13,7 +13,7 @@ export class SystemEvent {
   }
 }
 
-@HandlesMessage((e: SystemEvent) => e.type === eventType)
+@HandlesMessage((e: SystemEvent) => e.type === eventType, '')
 export class TestResolverHandler {
   constructor (
     @inject(MESSAGE_LOGGER) private readonly messageLogger: MessageLogger

--- a/packages/bus-core/src/transport/memory-queue.spec.ts
+++ b/packages/bus-core/src/transport/memory-queue.spec.ts
@@ -3,7 +3,7 @@ import { TestCommand, TestEvent, TestCommand2, TestSystemMessage } from '../test
 import { TransportMessage } from '../transport'
 import { Mock } from 'typemoq'
 import { Logger } from '@node-ts/logger-core'
-import { HandlerRegistry } from '../handler'
+import { HandlerRegistry, HandlerResolver } from '../handler'
 import { MessageAttributes } from '@node-ts/bus-messages'
 import * as faker from 'faker'
 
@@ -13,7 +13,7 @@ const command2 = new TestCommand2()
 
 describe('MemoryQueue', () => {
   let sut: MemoryQueue
-  const handledMessageNames = [TestCommand, TestEvent]
+  const handledMessages = [TestCommand, TestEvent]
   const messageOptions = new MessageAttributes({
     correlationId: faker.random.uuid()
    })
@@ -25,8 +25,8 @@ describe('MemoryQueue', () => {
 
     const handlerRegistry = Mock.ofType<HandlerRegistry>()
     handlerRegistry
-      .setup(h => h.subscribedBusMessages)
-      .returns(() => handledMessageNames)
+      .setup(h => h.messageSubscriptions)
+      .returns(() => handledMessages.map(h => ({ messageType: h }) as {} as HandlerResolver))
 
     await sut.initialize(handlerRegistry.object)
   })

--- a/packages/bus-core/src/transport/memory-queue.ts
+++ b/packages/bus-core/src/transport/memory-queue.ts
@@ -46,7 +46,9 @@ export class MemoryQueue implements Transport<InMemoryMessage> {
 
   async initialize (handlerRegistry: HandlerRegistry): Promise<void> {
     this.messagesWithHandlers = {}
-    handlerRegistry.subscribedBusMessages
+    handlerRegistry.messageSubscriptions
+      .filter(subscription => !!subscription.messageType)
+      .map(subscription => subscription.messageType!)
       .map(ctor => new ctor().$name)
       .forEach(messageName => this.messagesWithHandlers[messageName] = {})
   }

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
@@ -40,6 +40,8 @@ describe('RabbitMqTransport', () => {
     connection = await connectionFactory()
     channel = await connection.createChannel()
 
+    await channel.assertExchange(TestSystemMessage.NAME, 'fanout', { durable: true })
+
     await bootstrap.initialize(container)
   })
 

--- a/packages/bus-rabbitmq/test/test-system-message-handler.ts
+++ b/packages/bus-rabbitmq/test/test-system-message-handler.ts
@@ -8,7 +8,10 @@ export interface HandleChecker {
   check<T extends Object> (message: T, attributes: MessageAttributes): void
 }
 
-@HandlesMessage((m: TestSystemMessage) => m.name === TestSystemMessage.NAME)
+@HandlesMessage(
+  (m: TestSystemMessage) => m.name === TestSystemMessage.NAME,
+  TestSystemMessage.NAME
+)
 export class TestSystemMessageHandler {
 
   constructor (

--- a/packages/bus-rabbitmq/test/test-system-message.ts
+++ b/packages/bus-rabbitmq/test/test-system-message.ts
@@ -1,7 +1,7 @@
 import * as faker from 'faker'
 
 export class TestSystemMessage {
-  static readonly NAME = faker.random.uuid()
+  static readonly NAME = `integration-${faker.random.uuid()}`
   constructor (
     readonly name = TestSystemMessage.NAME
   ) {

--- a/packages/bus-sqs/src/sqs-transport.integration.ts
+++ b/packages/bus-sqs/src/sqs-transport.integration.ts
@@ -15,7 +15,6 @@ import * as uuid from 'uuid'
 import * as faker from 'faker'
 import { MessageAttributes } from '@node-ts/bus-messages'
 import { TestSystemMessageHandler } from '../test/test-system-message-handler'
-import { PromiseResult } from 'aws-sdk/lib/request'
 import { TestSystemMessage } from '../test/test-system-message'
 
 function getEnvVar (key: string): string {

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -242,7 +242,7 @@ export class SqsTransport implements Transport<SQS.Message> {
           )
         } else if (subscription.messageType) {
           const messageCtor = subscription.messageType
-          const topicName = this.sqsConfiguration.resolveTopicName(new messageCtor!().$name)
+          const topicName = this.sqsConfiguration.resolveTopicName(new messageCtor().$name)
           await this.createSnsTopic(topicName)
           topicArn = this.sqsConfiguration.resolveTopicArn(topicName)
         } else {

--- a/packages/bus-sqs/test/test-system-message-handler.ts
+++ b/packages/bus-sqs/test/test-system-message-handler.ts
@@ -2,9 +2,12 @@ import { HandlesMessage } from '@node-ts/bus-core'
 import { MessageAttributes } from '@node-ts/bus-messages'
 import { inject } from 'inversify'
 import { HANDLE_CHECKER, HandleChecker } from './test-command-handler'
-import { TestSystemMessage, testSystemMessageName } from './test-system-message'
+import { TestSystemMessage } from './test-system-message'
 
-@HandlesMessage((m: TestSystemMessage) => m.name === testSystemMessageName)
+@HandlesMessage(
+  (m: TestSystemMessage) => m.name === TestSystemMessage.NAME,
+  `arn:aws:sns:${process.env.AWS_REGION}:${process.env.AWS_ACCOUNT_ID}:${TestSystemMessage.NAME}`
+)
 export class TestSystemMessageHandler {
 
   constructor (

--- a/packages/bus-sqs/test/test-system-message.ts
+++ b/packages/bus-sqs/test/test-system-message.ts
@@ -1,10 +1,10 @@
 import * as faker from 'faker'
 
-export const testSystemMessageName = faker.random.uuid()
-
 export class TestSystemMessage {
+  static NAME = `integration-${faker.random.uuid()}`
+
   constructor (
-    readonly name = testSystemMessageName
+    readonly name = TestSystemMessage.NAME
   ) {
   }
 }

--- a/packages/bus-workflow/src/workflow/decorators/handles.ts
+++ b/packages/bus-workflow/src/workflow/decorators/handles.ts
@@ -31,14 +31,14 @@ export class WorkflowHandlesMetadata {
  * @param workflowDataProperty A field in the workflow data to look up matched message data on
  */
 export function Handles<
-  MessageType extends Message,
+  TMessage extends Message,
   WorkflowDataType extends WorkflowData,
   KeyType extends string,
-  TargetType extends WorkflowWithHandler<MessageType, WorkflowDataType, KeyType> =
-    WorkflowWithHandler<MessageType, WorkflowDataType, KeyType>
+  TargetType extends WorkflowWithHandler<TMessage, WorkflowDataType, KeyType> =
+    WorkflowWithHandler<TMessage, WorkflowDataType, KeyType>
 > (
-  messageConstructor: ClassConstructor<MessageType>,
-  messageLookup: (message: MessageType, messageOptions: MessageAttributes) => string | undefined,
+  messageConstructor: ClassConstructor<TMessage>,
+  messageLookup: (message: TMessage, messageOptions: MessageAttributes) => string | undefined,
   workflowDataProperty: keyof WorkflowDataType & string
 ): (target: TargetType, propertyKey: KeyType) => void {
   return (target: TargetType, propertyKey: string): void =>

--- a/packages/bus-workflow/src/workflow/message-workflow-mapping.ts
+++ b/packages/bus-workflow/src/workflow/message-workflow-mapping.ts
@@ -10,7 +10,7 @@ export class MessageWorkflowMapping<MessageType extends Message, WorkflowDataTyp
    */
   constructor (
     public lookupMessage: (message: MessageType, messageOptions?: MessageAttributes) => string | undefined,
-    readonly workflowDataProperty: string
+    readonly workflowDataProperty: keyof WorkflowDataType & string
   ) {
   }
 }

--- a/packages/bus-workflow/src/workflow/message-workflow-mapping.ts
+++ b/packages/bus-workflow/src/workflow/message-workflow-mapping.ts
@@ -10,7 +10,7 @@ export class MessageWorkflowMapping<MessageType extends Message, WorkflowDataTyp
    */
   constructor (
     public lookupMessage: (message: MessageType, messageOptions?: MessageAttributes) => string | undefined,
-    readonly workflowDataProperty: keyof WorkflowDataType & string
+    readonly workflowDataProperty: string
   ) {
   }
 }


### PR DESCRIPTION
This is an enhancement for the system message resolvers that allows the handler to specify which topic identifier the system messages are sourced from. This allows the library to subscribe queues to topics instead of doing this manually through infrastructure scripts.

It assumes that the topic is pre-existing as the application is no longer the owner of the topic. Ie: it assumes system messages are produced and topics/exchanges created by the external systems.