### PR TITLE
Allow SQS Transport to use Bus.Serializer to (de)serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "jest \"(src\\/.+\\.|/)spec\\.ts$\"",
     "test:unit:watch": "yarn run test:unit --watch",
-    "test:integration": "jest --runInBand \"bus-(core|message|workflow).*(src\\/.+\\.|/)integration\\.ts$\""
+    "test:integration": "jest --runInBand \"bus-(core|messages|workflow).*(src\\/.+\\.|/)integration\\.ts$\""
   },
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "jest \"(src\\/.+\\.|/)spec\\.ts$\"",
     "test:unit:watch": "yarn run test:unit --watch",
-    "test:integration": "jest --runInBand \"bus-(sqs).*(src\\/.+\\.|/)integration\\.ts$\""
+    "test:integration": "jest --runInBand \"bus-(core|message|workflow).*(src\\/.+\\.|/)integration\\.ts$\""
   },
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "jest \"(src\\/.+\\.|/)spec\\.ts$\"",
     "test:unit:watch": "yarn run test:unit --watch",
-    "test:integration": "jest --runInBand \"bus-(core|messages|workflow).*(src\\/.+\\.|/)integration\\.ts$\""
+    "test:integration": "jest --runInBand \"bus-(sqs).*(src\\/.+\\.|/)integration\\.ts$\""
   },
   "keywords": [
     "typescript",

--- a/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
+++ b/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
@@ -1,4 +1,3 @@
-import { Message } from '@node-ts/bus-messages'
 import { LOGGER_SYMBOLS, Logger } from '@node-ts/logger-core'
 import { Container, inject, injectable } from 'inversify'
 import { BUS_SYMBOLS } from '../bus-symbols'
@@ -86,7 +85,7 @@ export class ApplicationBootstrap {
 
   private async initializeTransport (): Promise<void> {
     if (this.transport.initialize) {
-      await this.transport.initialize(this.handlerRegistry)
+      await this.transport.initialize()
     }
   }
 }

--- a/packages/bus-core/src/bus-module.ts
+++ b/packages/bus-core/src/bus-module.ts
@@ -3,7 +3,7 @@ import { BUS_SYMBOLS, BUS_INTERNAL_SYMBOLS } from './bus-symbols'
 import { MessageAttributes } from '@node-ts/bus-messages'
 import { MemoryQueue } from './transport'
 import { ServiceBus, BusHooks } from './service-bus'
-import { JsonSerializer } from './serialization'
+import { JsonSerializer, MessageSerializer } from './serialization'
 import { ApplicationBootstrap } from './application-bootstrap'
 import { HandlerRegistry } from './handler'
 import { ClassConstructor } from './util'
@@ -27,6 +27,7 @@ export class BusModule extends ContainerModule {
       bindService(bind, BUS_SYMBOLS.ApplicationBootstrap, ApplicationBootstrap).inSingletonScope()
       bindService(bind, BUS_SYMBOLS.HandlerRegistry, HandlerRegistry).inSingletonScope()
       bindService(bind, BUS_SYMBOLS.JsonSerializer, JsonSerializer)
+      bindService(bind, BUS_SYMBOLS.MessageSerializer, MessageSerializer)
       bindService(bind, BUS_INTERNAL_SYMBOLS.BusHooks, BusHooks).inSingletonScope()
 
       bind(BUS_SYMBOLS.MessageHandlingContext).toConstantValue(new MessageAttributes())

--- a/packages/bus-core/src/bus-symbols.ts
+++ b/packages/bus-core/src/bus-symbols.ts
@@ -5,6 +5,7 @@ export const BUS_SYMBOLS = {
   HandlerRegistry: Symbol.for('@node-ts/bus-core/handler-registry'),
   ApplicationBootstrap: Symbol.for('@node-ts/bus-core/application-bootstrap'),
   JsonSerializer: Symbol.for('@node-ts/bus-core/json-serializer'),
+  MessageSerializer: Symbol.for('@node-ts/bus-core/message-serializer'),
   MessageHandlingContext: Symbol.for('@node-ts/bus-core/message-handling-context')
 }
 

--- a/packages/bus-core/src/handler/handler-registry.spec.ts
+++ b/packages/bus-core/src/handler/handler-registry.spec.ts
@@ -122,4 +122,27 @@ describe('HandlerRegistry', () => {
     })
   })
 
+  describe('when getting a messageType', () => {
+
+    beforeEach(() => {
+      sut.register((m: Message) => m.$name === messageName, symbol, handler, messageType)
+    })
+
+    it('return msg constructor when found', () => {
+      const msg = {
+        $name: TestEvent.NAME
+      }
+      const result = sut.getMessageType(msg as Message)
+      expect(result).toBe(TestEvent)
+    })
+
+    it('return undefined when not found', () => {
+      const msg = {
+        $name: 'bluhbluh-very-important-command'
+      }
+      const result = sut.getMessageType(msg as Message)
+      expect(result).toBeUndefined()
+    })
+  })
+
 })

--- a/packages/bus-core/src/handler/handler-registry.ts
+++ b/packages/bus-core/src/handler/handler-registry.ts
@@ -118,6 +118,23 @@ export class HandlerRegistry {
   }
 
   /**
+   * Gets the type consturctor for a given message name.
+   * This is used for deserialization
+   * @param message A message instance to resolve handlers for
+   */
+  getMessageType<TMessage extends MessageType> (message: TMessage): HandlerResolver['messageType'] {
+    const resolvedHandlers = this.handlerResolvers
+      .filter(resolvers => resolvers.resolver(message))
+
+    if (resolvedHandlers.length === 0) {
+      return undefined
+    }
+
+    // Assuming one message name is only associated with one message type
+    return resolvedHandlers[0].messageType
+  }
+
+  /**
    * Binds message handlers into the IoC container. All handlers should be stateless and are
    * bound in a transient scope.
    */

--- a/packages/bus-core/src/serialization/index.ts
+++ b/packages/bus-core/src/serialization/index.ts
@@ -1,2 +1,3 @@
 export * from './serializer'
 export * from './json-serializer'
+export * from './message-serializer'

--- a/packages/bus-core/src/serialization/message-serializer.spec.ts
+++ b/packages/bus-core/src/serialization/message-serializer.spec.ts
@@ -1,0 +1,75 @@
+// tslint:disable:max-classes-per-file no-inferred-empty-object-type
+import { Serializer } from './serializer'
+import { ClassConstructor } from '../util'
+import { MessageSerializer } from './message-serializer';
+import { Mock, IMock, It } from 'typemoq'
+import { HandlerRegistry } from '../handler'
+import * as faker from 'faker'
+
+class DummyMessage {
+  $name = 'bluh'
+  $version = 1
+  value: string
+
+  constructor (s: string) {
+    this.value = s
+  }
+}
+
+class ToxicSerializer implements Serializer {
+
+  serialize (msg: any): string {
+    return msg.$name as string
+  }
+
+  deserialize<T extends object> (msg: string, classType: ClassConstructor<T>): T {
+    return new classType(msg)
+  }
+}
+
+describe('MessageSerializer', () => {
+
+  let sut: MessageSerializer
+  let handlerRegistry: IMock<HandlerRegistry>
+  const msgName = 'dummy-message'
+
+  beforeEach(() => {
+    handlerRegistry = Mock.ofType<HandlerRegistry>()
+    handlerRegistry.setup(h => h.getMessageType(
+      It.isObjectWith({
+        $name: msgName
+      })
+    )).returns(() => DummyMessage)
+
+    const toxicSerializer = new ToxicSerializer()
+
+    sut = new MessageSerializer(
+      toxicSerializer,
+      handlerRegistry.object
+    )
+  })
+
+  it ('should use underlying serializer to serialize', () => {
+    const msg = {
+      $name: msgName
+    }
+    const result = sut.serialize(msg)
+    // As per toxic serializer's behavior
+    expect(result).toBe(msg.$name)
+  })
+
+  it ('should use underlying deserializer to deserialize', () => {
+    const msg = {
+      $name: msgName,
+      text: faker.random.words()
+    }
+    const raw = JSON.stringify(msg)
+
+    const result = sut.deserialize(raw) as DummyMessage
+
+    handlerRegistry.verifyAll()
+
+    // As per toxic serializer's behavior
+    expect(result.value).toBe(raw)
+  })
+})

--- a/packages/bus-core/src/serialization/message-serializer.ts
+++ b/packages/bus-core/src/serialization/message-serializer.ts
@@ -1,0 +1,39 @@
+import { injectable, inject } from 'inversify'
+import { Serializer } from './serializer'
+import { BUS_SYMBOLS } from '../bus-symbols'
+import { HandlerRegistry } from '../handler'
+import { Message } from '@node-ts/bus-messages'
+
+/**
+ * This a wrapper around the real serializer.
+ * Unlike JsonSerializer, whose sole job is parsing data,
+ * this class will do some plumbing work to look up the Handler Registry for
+ * the message constructor.
+ *
+ * Normally, transports will use this instead of the real serializer.
+ */
+@injectable()
+export class MessageSerializer {
+
+  constructor (
+    @inject(BUS_SYMBOLS.Serializer)
+      readonly serializer: Serializer,
+    @inject(BUS_SYMBOLS.HandlerRegistry)
+      readonly handlerRegistry: HandlerRegistry
+  ) {
+  }
+
+  serialize<T extends object> (obj: T): string {
+    return this.serializer.serialize(obj)
+  }
+
+  deserialize (val: string): Message {
+      const naiveDerializedMessage = JSON.parse(val) as Message
+      const messageType = this.handlerRegistry.getMessageType(naiveDerializedMessage)
+
+      return !!messageType ? this.serializer.deserialize(
+        val,
+        messageType
+      ) : naiveDerializedMessage
+  }
+}

--- a/packages/bus-core/src/transport/memory-queue.ts
+++ b/packages/bus-core/src/transport/memory-queue.ts
@@ -5,6 +5,7 @@ import { TransportMessage } from './transport-message'
 import { LOGGER_SYMBOLS, Logger } from '@node-ts/logger-core'
 import { HandlerRegistry } from '../handler'
 import { MessageType } from '../handler/handler'
+import { BUS_SYMBOLS } from '../bus-symbols'
 
 export const RETRY_LIMIT = 10
 
@@ -40,13 +41,15 @@ export class MemoryQueue implements Transport<InMemoryMessage> {
   private messagesWithHandlers: { [key: string]: {} }
 
   constructor (
-    @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger
+    @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger,
+    @inject(BUS_SYMBOLS.HandlerRegistry)
+      private readonly handlerRegistry: HandlerRegistry
   ) {
   }
 
-  async initialize (handlerRegistry: HandlerRegistry): Promise<void> {
+  async initialize (): Promise<void> {
     this.messagesWithHandlers = {}
-    handlerRegistry.messageSubscriptions
+    this.handlerRegistry.messageSubscriptions
       .filter(subscription => !!subscription.messageType)
       .map(subscription => subscription.messageType!)
       .map(ctor => new ctor().$name)

--- a/packages/bus-core/src/transport/transport.ts
+++ b/packages/bus-core/src/transport/transport.ts
@@ -1,6 +1,5 @@
 import { Event, Command, MessageAttributes } from '@node-ts/bus-messages'
 import { TransportMessage } from './transport-message'
-import { HandlerRegistry } from '../handler'
 
 /**
  * A transport adapter interface that enables the service bus to use a messaging technology.
@@ -51,9 +50,8 @@ export interface Transport<TransportMessageType = {}> {
    * An optional function that will be called when the service bus is starting. This is an
    * opportunity for the transport to see what messages need to be handled so that subscriptions
    * to the topics can be created.
-   * @param handlerRegistry The list of messages being handled by the bus that the transport needs to subscribe to.
    */
-  initialize? (handlerRegistry: HandlerRegistry): Promise<void>
+  initialize? (): Promise<void>
 
   /**
    * An optional function that will be called when the service bus is shutting down. This is an

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -38,7 +38,7 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     this.logger.info('Initializing RabbitMQ transport')
     this.connection = await this.connectionFactory()
     this.channel = await this.connection.createChannel()
-    await this.bindExchangesToQueue(this.handlerRegistry)
+    await this.bindExchangesToQueue()
     this.logger.info('RabbitMQ transport initialized')
   }
 
@@ -115,13 +115,13 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     }
   }
 
-  private async bindExchangesToQueue (handlerRegistry: HandlerRegistry): Promise<void> {
+  private async bindExchangesToQueue (): Promise<void> {
     await this.createDeadLetterQueue()
     await this.channel.assertQueue(
       this.configuration.queueName,
       { durable: true, deadLetterExchange }
     )
-    const subscriptionPromises = handlerRegistry.messageSubscriptions
+    const subscriptionPromises = this.handlerRegistry.messageSubscriptions
       .map(async subscription => {
 
         let exchangeName: string

--- a/packages/bus-sqs/package.json
+++ b/packages/bus-sqs/package.json
@@ -28,6 +28,7 @@
     "@types/amqplib": "^0.5.11",
     "@types/faker": "^4.1.5",
     "@types/uuid": "^3.4.4",
+    "class-transformer": "^0.2.3",
     "faker": "^4.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13",

--- a/packages/bus-sqs/src/sqs-transport.integration.ts
+++ b/packages/bus-sqs/src/sqs-transport.integration.ts
@@ -192,7 +192,7 @@ describe('SqsTransport', () => {
         await bus.send(testCommand, messageOptions)
       })
 
-      fit('should receive and dispatch to the handler', async () => {
+      it('should receive and dispatch to the handler', async () => {
         await sleep(1000 * 8)
         handleChecker.verify(
           h => h.check(It.isObjectWith({...testCommand}), It.isObjectWith(messageOptions)),

--- a/packages/bus-sqs/src/sqs-transport.integration.ts
+++ b/packages/bus-sqs/src/sqs-transport.integration.ts
@@ -25,7 +25,8 @@ function getEnvVar (key: string): string {
   return value
 }
 
-const resourcePrefix = 'integration'
+// Use a randomize number otherwise aws will disallow recreat just deleted queue
+const resourcePrefix = `integration-bus-sqs-${faker.random.number()}`
 const invalidSqsSnsCharacters = new RegExp('[^a-zA-Z0-9_-]', 'g')
 const normalizeMessageName = (messageName: string) => messageName.replace(invalidSqsSnsCharacters, '-')
 const AWS_REGION = getEnvVar('AWS_REGION')
@@ -174,7 +175,7 @@ describe('SqsTransport', () => {
     })
 
     describe('when sending a command', () => {
-      const testCommand = new TestCommand(uuid.v4())
+      const testCommand = new TestCommand(uuid.v4(), new Date())
       const messageOptions: MessageAttributes = {
         correlationId: faker.random.uuid(),
         attributes: {
@@ -191,7 +192,7 @@ describe('SqsTransport', () => {
         await bus.send(testCommand, messageOptions)
       })
 
-      it('should receive and dispatch to the handler', async () => {
+      fit('should receive and dispatch to the handler', async () => {
         await sleep(1000 * 8)
         handleChecker.verify(
           h => h.check(It.isObjectWith({...testCommand}), It.isObjectWith(messageOptions)),

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -2,7 +2,10 @@ import { Command, Event, Message, MessageAttributes, MessageAttributeMap } from 
 import { SNS, SQS } from 'aws-sdk'
 import { QueueAttributeMap } from 'aws-sdk/clients/sqs'
 import { inject, injectable } from 'inversify'
-import { Transport, TransportMessage, HandlerRegistry, BUS_SYMBOLS, Serializer } from '@node-ts/bus-core'
+import {
+  Transport, TransportMessage, HandlerRegistry,
+  BUS_SYMBOLS, MessageSerializer
+} from '@node-ts/bus-core'
 import { SqsTransportConfiguration } from './sqs-transport-configuration'
 import { Logger, LOGGER_SYMBOLS } from '@node-ts/logger-core'
 import { BUS_SQS_SYMBOLS, BUS_SQS_INTERNAL_SYMBOLS } from './bus-sqs-symbols'
@@ -47,15 +50,15 @@ export class SqsTransport implements Transport<SQS.Message> {
    */
   private registeredMessages: MessageRegistry = {}
 
-  private handlerRegistry: HandlerRegistry
-
   constructor (
     @inject(BUS_SQS_INTERNAL_SYMBOLS.Sqs) private readonly sqs: SQS,
     @inject(BUS_SQS_INTERNAL_SYMBOLS.Sns) private readonly sns: SNS,
     @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger,
     @inject(BUS_SQS_SYMBOLS.SqsConfiguration) private readonly sqsConfiguration: SqsTransportConfiguration,
-    @inject(BUS_SYMBOLS.Serializer)
-      private readonly serializer: Serializer
+    @inject(BUS_SYMBOLS.HandlerRegistry)
+      private readonly handlerRegistry: HandlerRegistry,
+    @inject(BUS_SYMBOLS.MessageSerializer)
+      private readonly messageSerializer: MessageSerializer
 
   ) {
   }
@@ -118,13 +121,7 @@ export class SqsTransport implements Transport<SQS.Message> {
         { transportAttributes: snsMessage.MessageAttributes, messageAttributes: attributes}
       )
 
-      const naiveDerializedMessage = JSON.parse(snsMessage.Message) as Message
-      const messageType = this.handlerRegistry.getMessageType(naiveDerializedMessage)
-
-      const domainMessage = !!messageType ? this.serializer.deserialize(
-        snsMessage.Message,
-        messageType
-      ) : naiveDerializedMessage
+      const domainMessage = this.messageSerializer.deserialize(snsMessage.Message)
 
       return {
         id: sqsMessage.MessageId,
@@ -151,9 +148,8 @@ export class SqsTransport implements Transport<SQS.Message> {
     await this.makeMessageVisible(message.raw)
   }
 
-  async initialize (handlerRegistry: HandlerRegistry): Promise<void> {
-    this.handlerRegistry = handlerRegistry
-    await this.assertServiceQueue(handlerRegistry)
+  async initialize (): Promise<void> {
+    await this.assertServiceQueue(this.handlerRegistry)
   }
 
   private async assertServiceQueue (handlerRegistry: HandlerRegistry): Promise<void> {
@@ -234,7 +230,7 @@ export class SqsTransport implements Transport<SQS.Message> {
     const snsMessage: SNS.PublishInput = {
       TopicArn: topicArn,
       Subject: message.$name,
-      Message: this.serializer.serialize(message),
+      Message: this.messageSerializer.serialize(message),
       MessageAttributes: attributeMap
     }
     this.logger.debug('Sending message to SNS', { snsMessage })

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -149,10 +149,10 @@ export class SqsTransport implements Transport<SQS.Message> {
   }
 
   async initialize (): Promise<void> {
-    await this.assertServiceQueue(this.handlerRegistry)
+    await this.assertServiceQueue()
   }
 
-  private async assertServiceQueue (handlerRegistry: HandlerRegistry): Promise<void> {
+  private async assertServiceQueue (): Promise<void> {
     await this.assertSqsQueue(
       this.sqsConfiguration.deadLetterQueueName
     )
@@ -169,7 +169,7 @@ export class SqsTransport implements Transport<SQS.Message> {
       serviceQueueAttributes
     )
 
-    await this.subscribeQueueToMessages(handlerRegistry)
+    await this.subscribeQueueToMessages()
     await this.attachPolicyToQueue(this.sqsConfiguration.queueUrl)
   }
 
@@ -237,7 +237,8 @@ export class SqsTransport implements Transport<SQS.Message> {
     await this.sns.publish(snsMessage).promise()
   }
 
-  private async subscribeQueueToMessages (handlerRegistry: HandlerRegistry): Promise<void> {
+  private async subscribeQueueToMessages (): Promise<void> {
+    const handlerRegistry = this.handlerRegistry
     const queueArn = this.sqsConfiguration.queueArn
     const queueSubscriptionPromises = handlerRegistry.messageSubscriptions
       .filter(subscription => !!subscription.messageType || !!subscription.topicIdentifier)

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -2,7 +2,7 @@ import { Command, Event, Message, MessageAttributes, MessageAttributeMap } from 
 import { SNS, SQS } from 'aws-sdk'
 import { QueueAttributeMap } from 'aws-sdk/clients/sqs'
 import { inject, injectable } from 'inversify'
-import { Transport, TransportMessage, HandlerRegistry } from '@node-ts/bus-core'
+import { Transport, TransportMessage, HandlerRegistry, BUS_SYMBOLS, Serializer } from '@node-ts/bus-core'
 import { SqsTransportConfiguration } from './sqs-transport-configuration'
 import { Logger, LOGGER_SYMBOLS } from '@node-ts/logger-core'
 import { BUS_SQS_SYMBOLS, BUS_SQS_INTERNAL_SYMBOLS } from './bus-sqs-symbols'
@@ -47,11 +47,16 @@ export class SqsTransport implements Transport<SQS.Message> {
    */
   private registeredMessages: MessageRegistry = {}
 
+  private handlerRegistry: HandlerRegistry
+
   constructor (
     @inject(BUS_SQS_INTERNAL_SYMBOLS.Sqs) private readonly sqs: SQS,
     @inject(BUS_SQS_INTERNAL_SYMBOLS.Sns) private readonly sns: SNS,
     @inject(LOGGER_SYMBOLS.Logger) private readonly logger: Logger,
-    @inject(BUS_SQS_SYMBOLS.SqsConfiguration) private readonly sqsConfiguration: SqsTransportConfiguration
+    @inject(BUS_SQS_SYMBOLS.SqsConfiguration) private readonly sqsConfiguration: SqsTransportConfiguration,
+    @inject(BUS_SYMBOLS.Serializer)
+      private readonly serializer: Serializer
+
   ) {
   }
 
@@ -113,10 +118,18 @@ export class SqsTransport implements Transport<SQS.Message> {
         { transportAttributes: snsMessage.MessageAttributes, messageAttributes: attributes}
       )
 
+      const naiveDerializedMessage = JSON.parse(snsMessage.Message) as Message
+      const messageType = this.handlerRegistry.getMessageType(naiveDerializedMessage)
+
+      const domainMessage = !!messageType ? this.serializer.deserialize(
+        snsMessage.Message,
+        messageType
+      ) : naiveDerializedMessage
+
       return {
         id: sqsMessage.MessageId,
         raw: sqsMessage,
-        domainMessage: JSON.parse(snsMessage.Message) as Message,
+        domainMessage,
         attributes
       }
     } catch (error) {
@@ -139,6 +152,7 @@ export class SqsTransport implements Transport<SQS.Message> {
   }
 
   async initialize (handlerRegistry: HandlerRegistry): Promise<void> {
+    this.handlerRegistry = handlerRegistry
     await this.assertServiceQueue(handlerRegistry)
   }
 
@@ -220,7 +234,7 @@ export class SqsTransport implements Transport<SQS.Message> {
     const snsMessage: SNS.PublishInput = {
       TopicArn: topicArn,
       Subject: message.$name,
-      Message: JSON.stringify(message),
+      Message: this.serializer.serialize(message),
       MessageAttributes: attributeMap
     }
     this.logger.debug('Sending message to SNS', { snsMessage })

--- a/packages/bus-sqs/test/test-command.ts
+++ b/packages/bus-sqs/test/test-command.ts
@@ -1,13 +1,20 @@
 import { Command } from '@node-ts/bus-messages'
+import { Type } from 'class-transformer'
 
 export class TestCommand extends Command {
   static NAME = '@node-ts/bus-core/test-command'
   $name = TestCommand.NAME
   $version = 1
 
+  @Type(() => Date)
+  readonly date: Date
+
   constructor (
-    readonly value: string
+    readonly value: string,
+    date: Date
   ) {
     super()
+
+    this.date = date
   }
 }


### PR DESCRIPTION
This PR changes SQS transport to use Bus.Serializer to handle its message serialization/deserialization. 

This PR also refactor `Transport` so its `initialize` function doesn't require `handlerRegistry`. We hope the implementation take `handlerRegistry` from container. 