### PR TITLE
Provide raw message to error hook

### DIFF
--- a/packages/bus-core/src/service-bus/bus-hooks.ts
+++ b/packages/bus-core/src/service-bus/bus-hooks.ts
@@ -5,22 +5,26 @@ import { HookCallback, HookAction, ErrorHookCallback, StandardHookCallback } fro
  * A singleton repository for all hook events registered with the Bus. This persists across scope boundaries
  * so that Bus instances that are scoped to a message handling context still have access to the global set
  * of registered hooks
+ *
+ * @template TransportMessageType - The raw message type returned from the transport that will be passed to the hooks
+ * @example BusHooks<InMemoryMessage>
+ * @example BusHooks<SQS.Message>
  */
 @injectable()
-export class BusHooks {
-  private messageHooks: { [key: string]: HookCallback[] } = {
+export class BusHooks<TransportMessageType = unknown> {
+  private messageHooks: { [key: string]: HookCallback<TransportMessageType>[] } = {
     send: [],
     publish: [],
     error: []
   }
 
-  on (action: Extract<HookAction, 'error'>, callback: ErrorHookCallback): void
+  on (action: Extract<HookAction, 'error'>, callback: ErrorHookCallback<TransportMessageType>): void
   on (action: Exclude<HookAction, 'error'>, callback: StandardHookCallback): void
-  on (action: HookAction, callback: HookCallback): void {
+  on (action: HookAction, callback: HookCallback<TransportMessageType>): void {
     this.messageHooks[action].push(callback)
   }
 
-  off (action: HookAction, callback: HookCallback): void {
+  off (action: HookAction, callback: HookCallback<TransportMessageType>): void {
     const index = this.messageHooks[action].indexOf(callback)
     if (index >= 0) {
       this.messageHooks[action].splice(index, 1)
@@ -35,7 +39,7 @@ export class BusHooks {
     return this.messageHooks.publish as StandardHookCallback[]
   }
 
-  get error (): ErrorHookCallback[] {
-    return this.messageHooks.error as ErrorHookCallback[]
+  get error (): ErrorHookCallback<TransportMessageType>[] {
+    return this.messageHooks.error as ErrorHookCallback<TransportMessageType>[]
   }
 }

--- a/packages/bus-core/src/service-bus/bus.ts
+++ b/packages/bus-core/src/service-bus/bus.ts
@@ -11,13 +11,15 @@ export enum BusState {
 export type HookAction = 'send' | 'publish' | 'error'
 
 export type StandardHookCallback = (
-  message: Message, messageAttributes?: MessageAttributes
+  message: Message,
+  messageAttributes?: MessageAttributes
 ) => Promise<void> | void
 
-export type ErrorHookCallback<T> = (
-  message: Message, error: Error,
+export type ErrorHookCallback<TransportMessageType> = (
+  message: Message,
+  error: Error,
   messageAttributes?: MessageAttributes,
-  rawMessage?: TransportMessage<T>
+  rawMessage?: TransportMessage<TransportMessageType>
 ) => Promise<void> | void
 
 export type HookCallback<TransportMessageType> = StandardHookCallback | ErrorHookCallback<TransportMessageType>
@@ -63,12 +65,14 @@ export interface Bus {
   stop (): Promise<void>
 
   /**
-   * Registers a @param callback function that is invoked for every instance of @param action occuring
+   * Registers a @param callback function that is invoked for every instance of @param action occurring
+   * @template TransportMessageType - The raw message type returned from the transport that will be passed to the hooks
    */
-  on<T> (action: HookAction, callback: HookCallback<T>): void
+  on<TransportMessageType = unknown> (action: HookAction, callback: HookCallback<TransportMessageType>): void
 
   /**
    * Deregisters a @param callback function from firing when an @param action occurs
+   * @template TransportMessageType - The raw message type returned from the transport that will be passed to the hooks
    */
-  off<T> (action: HookAction, callback: HookCallback<T>): void
+  off<TransportMessageType = unknown> (action: HookAction, callback: HookCallback<TransportMessageType>): void
 }

--- a/packages/bus-core/src/service-bus/bus.ts
+++ b/packages/bus-core/src/service-bus/bus.ts
@@ -1,4 +1,5 @@
 import { Event, Command, MessageAttributes, Message } from '@node-ts/bus-messages'
+import { TransportMessage } from '../transport'
 
 export enum BusState {
   Stopped = 'stopped',
@@ -13,11 +14,13 @@ export type StandardHookCallback = (
   message: Message, messageAttributes?: MessageAttributes
 ) => Promise<void> | void
 
-export type ErrorHookCallback = (
-  message: Message, error: Error, messageAttributes?: MessageAttributes
+export type ErrorHookCallback<T> = (
+  message: Message, error: Error,
+  messageAttributes?: MessageAttributes,
+  rawMessage?: TransportMessage<T>
 ) => Promise<void> | void
 
-export type HookCallback = StandardHookCallback | ErrorHookCallback
+export type HookCallback<TransportMessageType> = StandardHookCallback | ErrorHookCallback<TransportMessageType>
 
 
 export interface Bus {
@@ -62,10 +65,10 @@ export interface Bus {
   /**
    * Registers a @param callback function that is invoked for every instance of @param action occuring
    */
-  on (action: HookAction, callback: HookCallback): void
+  on<T> (action: HookAction, callback: HookCallback<T>): void
 
   /**
    * Deregisters a @param callback function from firing when an @param action occurs
    */
-  off (action: HookAction, callback: HookCallback): void
+  off<T> (action: HookAction, callback: HookCallback<T>): void
 }

--- a/packages/bus-core/src/service-bus/service-bus.integration.ts
+++ b/packages/bus-core/src/service-bus/service-bus.integration.ts
@@ -167,7 +167,7 @@ describe('ServiceBus', () => {
         callback.verifyAll()
       })
 
-      fit('should trigger error hook if registered', async () => {
+      it('should trigger error hook if registered', async () => {
         const errorCallback = jest.fn()
         setupErroneousCallback()
 

--- a/packages/bus-core/src/service-bus/service-bus.integration.ts
+++ b/packages/bus-core/src/service-bus/service-bus.integration.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-classes-per-file
 import { ServiceBus } from './service-bus'
-import { MemoryQueue } from '../transport'
+import { InMemoryMessage, MemoryQueue, TransportMessage } from '../transport'
 import { BusState } from './bus'
 import { TestEvent } from '../test/test-event'
 import { TestEvent2 } from '../test/test-event-2'
@@ -177,6 +177,17 @@ describe('ServiceBus', () => {
 
         callback.verifyAll()
 
+        const expectedTransportMessage: TransportMessage<InMemoryMessage> = {
+          id: undefined,
+          attributes: new MessageAttributes(),
+          domainMessage: event,
+          raw: {
+            inFlight: true,
+            seenCount: 1,
+            payload: event
+          }
+        }
+
         expect(errorCallback).toHaveBeenCalledTimes(1)
         expect(errorCallback).toHaveBeenCalledWith(
           event,
@@ -190,9 +201,7 @@ describe('ServiceBus', () => {
             attributes: expect.anything(),
             stickyAttributes: expect.anything()
           }),
-          expect.objectContaining({
-            raw: expect.anything()
-          })
+          expect.objectContaining(expectedTransportMessage)
         )
         sut.off('error', errorCallback)
       })

--- a/packages/bus-core/src/service-bus/service-bus.integration.ts
+++ b/packages/bus-core/src/service-bus/service-bus.integration.ts
@@ -167,7 +167,7 @@ describe('ServiceBus', () => {
         callback.verifyAll()
       })
 
-      it('should trigger error hook if registered', async () => {
+      fit('should trigger error hook if registered', async () => {
         const errorCallback = jest.fn()
         setupErroneousCallback()
 
@@ -189,6 +189,9 @@ describe('ServiceBus', () => {
             correlationId: undefined,
             attributes: expect.anything(),
             stickyAttributes: expect.anything()
+          }),
+          expect.objectContaining({
+            raw: expect.anything()
           })
         )
         sut.off('error', errorCallback)

--- a/packages/bus-core/src/service-bus/service-bus.ts
+++ b/packages/bus-core/src/service-bus/service-bus.ts
@@ -1,6 +1,6 @@
 import { injectable, inject, optional } from 'inversify'
 import autobind from 'autobind-decorator'
-import { Bus, BusState, HookAction, HookCallback } from './bus'
+import { Bus, BusState } from './bus'
 import { BUS_SYMBOLS, BUS_INTERNAL_SYMBOLS } from '../bus-symbols'
 import { Transport, TransportMessage } from '../transport'
 import { Event, Command, MessageAttributes, Message } from '@node-ts/bus-messages'
@@ -98,9 +98,8 @@ export class ServiceBus implements Bus {
   // tslint:disable-next-line:member-ordering
   on = this.busHooks.on.bind(this.busHooks)
 
-  off (action: HookAction, callback: HookCallback): void {
-    this.busHooks.off(action, callback)
-  }
+  // tslint:disable-next-line:member-ordering
+  off = this.busHooks.off.bind(this.busHooks)
 
   private async applicationLoop (): Promise<void> {
     this.runningWorkerCount++
@@ -131,7 +130,8 @@ export class ServiceBus implements Bus {
           await Promise.all(this.busHooks.error.map(callback => callback(
             message.domainMessage as Message,
             (error as Error),
-            message.attributes
+            message.attributes,
+            message
           )))
           await this.transport.returnMessage(message)
           return false


### PR DESCRIPTION
This PR modifies error hook so that full message body was provided as the forth parameter.

The goal of such change is to allow consumer to access more information while handling error. An example is that, consumer might want to decide whether to spit out an error log based on how many times the message has been retried.