### PR TITLE
Expose sqs wait time via config

### DIFF
--- a/packages/bus-sqs/src/sqs-transport-configuration.ts
+++ b/packages/bus-sqs/src/sqs-transport-configuration.ts
@@ -75,6 +75,15 @@ export interface SqsTransportConfiguration {
   maxReceiveCount?: number
 
   /**
+   * The wait time on sqs.receiveMessage, setting it to 0 will essentially turn it to short polling.
+   *
+   * It also has a impact on shutdown duration because sqs,receiveMessage is a non interruptable action.
+   *
+   * @default 10
+   */
+  waitTimeSeconds?: number
+
+  /**
    * A resolver function that maps a message name to an SNS topic.
    * @param messageName Name of the message to map
    * @returns An SNS topic name where messages of @param messageName are sent. Must be compatible with SNS topic naming

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -17,6 +17,7 @@ export const MAX_SQS_VISIBILITY_TIMEOUT_SECONDS: Seconds = 43200
 const DEFAULT_VISIBILITY_TIMEOUT = 30
 const DEFAULT_MAX_RETRY_COUNT = 10
 const MILLISECONDS_IN_SECONDS = 1000
+const DEFAULT_WAIT_TIME_SECONDS = 10
 type Seconds = number
 type Milliseconds = number
 
@@ -93,7 +94,7 @@ export class SqsTransport implements Transport<SQS.Message> {
   async readNextMessage (): Promise<TransportMessage<SQS.Message> | undefined> {
     const receiveRequest: SQS.ReceiveMessageRequest = {
       QueueUrl: this.sqsConfiguration.queueUrl,
-      WaitTimeSeconds: 10,
+      WaitTimeSeconds: this.sqsConfiguration.waitTimeSeconds || DEFAULT_WAIT_TIME_SECONDS,
       MaxNumberOfMessages: 1,
       MessageAttributeNames: ['.*'],
       AttributeNames: ['ApproximateReceiveCount']


### PR DESCRIPTION
This PR exposes SQS receive's wait time via config. 

Use cases: 
- Reduce shut down duration 
- Turn long polling to short polling