### PR TITLE
Migrating to modest queue

### DIFF
--- a/packages/bus-redis/README.md
+++ b/packages/bus-redis/README.md
@@ -42,57 +42,12 @@ The Redis transport has the following configuration:
 * **queueName** *(required)* The name of the service queue to create and read messages from.
 * **connectionString** *(required)* A redis formatted connection string that's used to connect to the Redis instance
 * **maxRetries** *(optional)* The number of attempts to retry failed messages before they're routed to the dead letter queue. *Default: 10*
+* **visibilityTimeout** *(optional)* The time taken before a message has been deemed to have failed or stalled. Once this time has been exceeded the message will be re-added to queue. *Default: 30000*
+* **withScheduler** *(optional)* The scheduler is a worker that checks messages if any messages have exceeded the visibility timeout. If they have, the are re added to the queue. It might be more performant to have only a few of these running. *Default: true*
 ## Development
 
 Local development can be done with the aid of docker to run the required infrastructure. To do so, run:
 
 ```bash
 docker run --name redis -e ALLOW_EMPTY_PASSWORD=yes -p 6379:6379 bitnami/redis
-```
-
-### Viewing Queues
-To view the queues and replay messages that end are sent to the failed queue, You can make use of [this](https://gitlab.com/ersutton/docker-arena).
-
-For local development, a simple configuration file like this:
-
-```json
-// arena.json
-{
-  "queues": [
-    {
-      "name": "node-ts/bus-redis-test",
-      "hostId": "Integration test queue",
-      "type": "bullmq",
-      "redis": {
-          "port": 6379,
-          "host": "redis"
-      }
-    }
-  ]
-}
-```
-
-Accompanied with a `docker-compose.yml` to assist with networking:
-
-```yml
-# docker-compose.yml
-version: '3'
-
-services:
-  redis:
-    image: bitnami/redis
-    container_name: redis
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-    ports:
-      - "6379:6379"
-  arena:
-    image: registry.gitlab.com/ersutton/docker-arena:latest
-    container_name: arena
-    links:
-      - redis
-    ports:
-      - "4567:4567"
-    volumes:
-      - "./arena.json:/opt/arena/index.json"
 ```

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "bullmq": "^1.40.1",
+    "modest-queue": "^0.0.6",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "modest-queue": "^0.1.3",
+    "modest-queue": "^0.3.0",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "modest-queue": "^0.3.0",
+    "modest-queue": "^0.4.0",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "modest-queue": "^0.1.0",
+    "modest-queue": "^0.1.3",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "modest-queue": "^0.0.6",
+    "modest-queue": "^0.1.0",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "^0.3.2",
-    "modest-queue": "^0.4.0",
+    "modest-queue": "^0.4.1",
     "ioredis": "^4.27.7",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/packages/bus-redis/src/bus-redis-module.ts
+++ b/packages/bus-redis/src/bus-redis-module.ts
@@ -1,10 +1,9 @@
 import { ContainerModule } from 'inversify'
-import { BUS_REDIS_INTERNAL_SYMBOLS, BUS_REDIS_SYMBOLS } from './bus-redis-symbols'
-import { RedisMessage, RedisMqTransport } from './redis-transport'
+import { BUS_REDIS_INTERNAL_SYMBOLS } from './bus-redis-symbols'
+import { RedisMqTransport } from './redis-transport'
 import { bindLogger } from '@node-ts/logger-core'
-import { RedisTransportConfiguration } from './redis-transport-configuration'
 import { BUS_SYMBOLS, Transport } from '@node-ts/bus-core'
-import Redis from 'ioredis'
+import { Message as QueueMessage } from 'modest-queue'
 
 export class BusRedisModule extends ContainerModule {
   constructor () {
@@ -14,16 +13,8 @@ export class BusRedisModule extends ContainerModule {
         .inSingletonScope()
       bindLogger(bind, RedisMqTransport)
 
-      rebind<Transport<RedisMessage>>(BUS_SYMBOLS.Transport)
+      rebind<Transport<QueueMessage>>(BUS_SYMBOLS.Transport)
         .toDynamicValue(c => c.container.get<RedisMqTransport>(BUS_REDIS_INTERNAL_SYMBOLS.RedisTransport))
-
-      bind(BUS_REDIS_INTERNAL_SYMBOLS.RedisFactory)
-        .toFactory(c => async () => {
-          const configuration = c.container
-            .get<RedisTransportConfiguration>(BUS_REDIS_SYMBOLS.TransportConfiguration)
-          return new Redis(configuration.connectionString)
-        })
-
     })
   }
 }

--- a/packages/bus-redis/src/bus-redis-symbols.ts
+++ b/packages/bus-redis/src/bus-redis-symbols.ts
@@ -3,6 +3,5 @@ export const BUS_REDIS_SYMBOLS = {
 }
 
 export const BUS_REDIS_INTERNAL_SYMBOLS = {
-  RedisTransport: Symbol.for('node-ts/bus-redis/redis-transport'),
-  RedisFactory: Symbol.for('node-ts/bus-redis/redis')
+  RedisTransport: Symbol.for('node-ts/bus-redis/redis-transport')
 }

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -24,7 +24,7 @@ export interface RedisTransportConfiguration {
 
   /**
    * The time taken before a message has been deemed to have failed or stalled. Once this time has been exceeded
-   * the message will be re-added to the queue.
+   * the message will be re-added to the end of the queue.
    * @default 30000 (30 seconds)
    */
   visibilityTimeout?: number

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -24,7 +24,7 @@ export interface RedisTransportConfiguration {
 
   /**
    * The time taken before a message has been deemed to have failed or stalled. Once this time has been exceeded
-   * the message will be re-added to the end of the queue.
+   * the message will be re-added to queue.
    * @default 30000 (30 seconds)
    */
   visibilityTimeout?: number

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -30,7 +30,7 @@ export interface RedisTransportConfiguration {
   visibilityTimeout?: number
 
   /**
-   * The scheduler is a worker that checks messages if any messages have exceeded thy
+   * The scheduler is a worker that checks messages if any messages have exceeded the
    * visibility timeout. If they have, the are re added to the queue. It might be more performant to have only a few of these
    * running.
    * @default true

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -21,4 +21,20 @@ export interface RedisTransportConfiguration {
    * @default 10
    */
   maxRetries?: number
+
+  /**
+   * The time taken before a message has been deemed to have failed or stalled. Once this time has been exceeded
+   * the message will be re-added to the queue.
+   * @default 30000 (30 seconds)
+   */
+  visibilityTimeout?: number
+
+  /**
+   * The scheduler is a worker that checks messages if any messages have exceeded thy
+   * visibility timeout. If they have, the are re added to the queue. It might be more performant to have only a few of these
+   * running.
+   * @default true
+   */
+  withScheduler?: boolean
+
 }

--- a/packages/bus-redis/src/redis-transport.integration.ts
+++ b/packages/bus-redis/src/redis-transport.integration.ts
@@ -16,7 +16,6 @@ import { RedisTransportConfiguration } from './redis-transport-configuration'
 import * as faker from 'faker'
 import { TestSystemMessageHandler } from '../test/test-system-message-handler'
 import { Mock, IMock, It, Times } from 'typemoq'
-import { Job } from 'bullmq'
 import * as uuid from 'uuid'
 import { MessageAttributes } from '@node-ts/bus-messages'
 import { TestSystemMessage } from '../test/test-system-message'
@@ -40,16 +39,6 @@ describe('RedisTransport', () => {
   let container: TestContainer
   let bootstrap: ApplicationBootstrap
   let handleChecker: IMock<HandleChecker>
-
-  /**
-   * removes all jobs irrespective of their state
-   * 'completed' | 'wait' | 'active' | 'paused' | 'delayed' | 'failed'
-   */
-  async function purgeQueue() {
-    return Promise.all(
-      ['completed','wait','active','paused','delayed','failed']
-        .map(jobState => sut['queue'].clean(2000, 100, jobState as any)))
-  }
 
   beforeAll(async () => {
     handleChecker = Mock.ofType<HandleChecker>()
@@ -92,7 +81,7 @@ describe('RedisTransport', () => {
       await bus.send(testCommand, messageOptions)
     })
     afterAll(async () => {
-      await purgeQueue()
+      await sut['queue'].destroyQueue()
     })
 
     it('it should receive and dispatch to the handler', async () => {
@@ -103,21 +92,19 @@ describe('RedisTransport', () => {
       )
     })
     it(`it should not move the completed message to the completed queue`, async () => {
-      const completedCount = await sut['queue'].getCompletedCount()
-      expect(completedCount).toEqual(0)
+      const completedCount = await sut['queue'].queueStats()
+      expect(completedCount).toEqual({dlq: 0, inflight: 0, queue:0})
     })
   })
 
   describe('when retrying a poisoned message', () => {
     const poisonedMessage = new TestPoisonedMessage(faker.random.uuid())
-    let failedMessages: Job<any,any,string>[]
     beforeAll(async () => {
       await bus.publish(poisonedMessage)
       await sleep(2000)
-      failedMessages = await sut['queue'].getFailed()
     })
     afterAll(async () => {
-      await purgeQueue()
+      await sut['queue'].destroyQueue()
     })
 
     it('it should attempt to process the message configuration.maxRetries times', () => {
@@ -127,65 +114,51 @@ describe('RedisTransport', () => {
       )
     })
 
-    it('it should have been moved to the failed queue', () => {
-      expect(failedMessages).toHaveLength(1)
-      console.error(failedMessages[0])
-      const deserialisedMessage = JSON.parse(failedMessages[0].data.message)
-      expect(deserialisedMessage.id).toEqual(poisonedMessage.id)
+    it('it should have been moved to the dead letter queue', async () => {
+      const queueStats = await sut['queue'].queueStats()
+      expect(queueStats).toEqual({dlq: 1, inflight: 0, queue:0})
     })
   })
 
   describe('when failing a message', () => {
     const failMessage = new TestFailMessage(faker.random.uuid())
     const correlationId = faker.random.uuid()
-    let failedMessages: Job<any,any,string>[]
-    let completedCount: number
-    let delayedCount: number
-    let activeCount: number
-    let waitingCount: number
+    let queueStats: {
+      queue: number
+      dlq: number
+      inflight: number
+    }
 
     beforeAll(async () => {
       await bus.publish(failMessage, new MessageAttributes({ correlationId }))
       await sleep(2000)
-      failedMessages = await sut['queue'].getFailed()
-      completedCount = await sut['queue'].getCompletedCount()
-      delayedCount = await sut['queue'].getDelayedCount()
-      activeCount = await sut['queue'].getActiveCount()
-      waitingCount = await sut['queue'].getWaitingCount()
+      queueStats = await sut['queue'].queueStats()
     })
     afterAll(async () => {
-      await purgeQueue()
+      await sut['queue'].destroyQueue()
     })
 
-    it('it should be moved to the failed queue', () => {
-      expect(failedMessages).toHaveLength(1)
-    })
-    it('there should be no other messages in the other queues', () => {
-      expect(completedCount).toEqual(0)
-      expect(delayedCount).toEqual(0)
-      expect(activeCount).toEqual(0)
-      expect(waitingCount).toEqual(0)
-    })
-
-    it('it should retain the same message attributes', () => {
-      expect(failedMessages[0].data.correlationId).toEqual(correlationId)
+    it('it should be moved to the dead letter queue', () => {
+      expect(queueStats).toEqual({dlq: 1, inflight: 0, queue:0})
     })
   })
 
   describe('when a system message is received', () => {
-    const message = new TestSystemMessage()
+    const testMessage = new TestSystemMessage()
+    const serializedMessage = JSON.stringify(testMessage)
+    const message = { message : serializedMessage }
     beforeAll(async () => {
-      await sut['queue'].add(message.name, {message: JSON.stringify(message)})
+      await sut['queue'].publish(JSON.stringify(message))
     })
 
     afterAll(async () => {
-      await purgeQueue()
+      await sut['queue'].destroyQueue()
     })
 
     it('it should handle the system message', async () => {
       await sleep(2000)
       handleChecker.verify(
-        h => h.check(It.isObjectWith({...message}), It.isAny()),
+        h => h.check(It.isObjectWith({...testMessage}), It.isAny()),
         Times.once()
       )
     })

--- a/packages/bus-redis/src/redis-transport.integration.ts
+++ b/packages/bus-redis/src/redis-transport.integration.ts
@@ -92,7 +92,7 @@ describe('RedisTransport', () => {
         Times.once()
       )
     })
-    it(`it should not move the completed message to the completed queue`, async () => {
+    it(`The queue stats should be empty as all messages have been completed`, async () => {
       const completedCount = await sut['queue'].queueStats()
       expect(completedCount).toEqual({dlq: 0, inflight: 0, queue:0, delayed: 0})
     })

--- a/packages/bus-redis/src/redis-transport.ts
+++ b/packages/bus-redis/src/redis-transport.ts
@@ -58,9 +58,9 @@ export class RedisTransport implements Transport<QueueMessage> {
     // Subscribe this queue to listen to all messages in the HandlerRegistry
     await this.subscribeToMessagesOfInterest()
     this.queue = new ModestQueue({
-      queueName:this.configuration.queueName,
-      connectionString:this.configuration.connectionString,
-      visibilityTimeout:this.configuration.visibilityTimeout ?? 30000,
+      queueName: this.configuration.queueName,
+      connectionString: this.configuration.connectionString,
+      visibilityTimeout: this.configuration.visibilityTimeout ?? 30000,
       maxAttempts: 3,
       withScheduler: this.configuration.withScheduler
     })
@@ -74,7 +74,6 @@ export class RedisTransport implements Transport<QueueMessage> {
       .map(async subscription => {
         if (subscription.messageType) {
           const messageCtor = subscription.messageType
-          console.error(subscription)
           return this.connection.sadd(`${this.subscriptionsKeyPrefix}${new messageCtor().$name}`, this.configuration.queueName)
         } else {
           throw new Error(`Unable to messageType to this queue: ${subscription}`)
@@ -116,8 +115,6 @@ export class RedisTransport implements Transport<QueueMessage> {
 
     this.logger.debug('Received message from Redis', {redisMessage: maybeMessage.message})
     const { message, ...attributes}: Payload = JSON.parse(maybeMessage.message)
-    console.error('ed!')
-    console.error(message)
     const domainMessage = this.messageSerializer.deserialize(message)
 
     return {

--- a/packages/bus-redis/src/redis-transport.ts
+++ b/packages/bus-redis/src/redis-transport.ts
@@ -62,7 +62,8 @@ export class RedisTransport implements Transport<QueueMessage> {
       connectionString: this.configuration.connectionString,
       visibilityTimeout: this.configuration.visibilityTimeout ?? 30000,
       maxAttempts: 3,
-      withScheduler: this.configuration.withScheduler
+      withScheduler: this.configuration.withScheduler,
+      withDelayedScheduler: false
     })
     await this.queue.initialize()
 
@@ -160,7 +161,7 @@ export class RedisTransport implements Transport<QueueMessage> {
     const serializedPayload = JSON.stringify(payload)
     const queues = await this.getQueuesSubscribedToMessage(message)
     await Promise.all(queues.map(async queueName => {
-      const queue = new ModestQueue({queueName, connection: this.connection, withScheduler: false})
+      const queue = new ModestQueue({queueName, connection: this.connection, withScheduler: false, withDelayedScheduler: false})
       await queue.initialize()
       await queue.publish(serializedPayload)
       await queue.dispose()

--- a/packages/bus-redis/tsconfig.json
+++ b/packages/bus-redis/tsconfig.json
@@ -9,6 +9,7 @@
     "src/**/test"
   ],
   "compilerOptions": {
+    "lib": ["ES2020"],
     "outDir": "./dist",
     "baseUrl": "./",
     // bullmq types are busted

--- a/packages/bus-redis/tsconfig.json
+++ b/packages/bus-redis/tsconfig.json
@@ -9,7 +9,6 @@
     "src/**/test"
   ],
   "compilerOptions": {
-    "lib": ["ES2020"],
     "outDir": "./dist",
     "baseUrl": "./",
     // bullmq types are busted

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "@node-ts/*": ["./*/src"]
     },
+    "lib": ["ES2020"],
     "noUnusedLocals": false,
     "noUnusedParameters": false
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,10 +8445,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-modest-queue@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.1.3.tgz#5817332b1dfade35feac2b0aa94e1b0090d862a3"
-  integrity sha512-DuB4DuBj9aEcuFMo3a/k6ht2/a4y7cB8cOVi7X0bNKusLOhqWP57szRrMSOUHubE+3ENonTUdSIuCWrJ565P8A==
+modest-queue@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.3.0.tgz#871f0fa9f8247c168829a6c32d6a698083f9f847"
+  integrity sha512-auEzwmS0OAlOgldRcm8Hpb4fF5Rd7jnPry8ey2NzIodon1QdCWHAsepG98qjZZztj3Og0GOfG5q0FFBBTFjq7w==
   dependencies:
     class-transformer "^0.4.0"
     ioredis "^4.27.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,10 +8445,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-modest-queue@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.0.6.tgz#263e74599b3d57d8e6b1451bd953a2721ecf69f7"
-  integrity sha512-TMz0+8MQNVzad6l6+YHF2mSzvuDRvzf0n6Ph8w95CrfvbAQMDuobOeGe4FW236Qw5qJDa2uEXojjGDJXqUKurw==
+modest-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.1.0.tgz#22d5fe7820f957d88f0bd74db4b0d03d09e194d0"
+  integrity sha512-b0FUp/iOYqBfu202sskUAb7jHdPvblXOfZKMNNEt+kJItS/iApQPtVblTRyFOR5WC+7Dg5I4BZuAQORJDGh6jA==
   dependencies:
     class-transformer "^0.4.0"
     ioredis "^4.27.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,10 +8445,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-modest-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.1.0.tgz#22d5fe7820f957d88f0bd74db4b0d03d09e194d0"
-  integrity sha512-b0FUp/iOYqBfu202sskUAb7jHdPvblXOfZKMNNEt+kJItS/iApQPtVblTRyFOR5WC+7Dg5I4BZuAQORJDGh6jA==
+modest-queue@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.1.3.tgz#5817332b1dfade35feac2b0aa94e1b0090d862a3"
+  integrity sha512-DuB4DuBj9aEcuFMo3a/k6ht2/a4y7cB8cOVi7X0bNKusLOhqWP57szRrMSOUHubE+3ENonTUdSIuCWrJ565P8A==
   dependencies:
     class-transformer "^0.4.0"
     ioredis "^4.27.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,10 +8445,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-modest-queue@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.3.0.tgz#871f0fa9f8247c168829a6c32d6a698083f9f847"
-  integrity sha512-auEzwmS0OAlOgldRcm8Hpb4fF5Rd7jnPry8ey2NzIodon1QdCWHAsepG98qjZZztj3Og0GOfG5q0FFBBTFjq7w==
+modest-queue@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.4.0.tgz#917d264c1ff2d59594f7a6ab32b900d9d23090bd"
+  integrity sha512-k+fpy1yDqLg2XIbzajOm+xoM7cz89k/Sffa1RX7umgKE4jpgKVkgbkkl1f5oFFiPR4SJk42Jq7qmPAM60L/u9w==
   dependencies:
     class-transformer "^0.4.0"
     ioredis "^4.27.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,10 +8445,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-modest-queue@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.4.0.tgz#917d264c1ff2d59594f7a6ab32b900d9d23090bd"
-  integrity sha512-k+fpy1yDqLg2XIbzajOm+xoM7cz89k/Sffa1RX7umgKE4jpgKVkgbkkl1f5oFFiPR4SJk42Jq7qmPAM60L/u9w==
+modest-queue@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.4.1.tgz#2a21e7f1e9bdf807ca00ed16f01c0a9349aaa1f8"
+  integrity sha512-SLkGUr3qTrxKk7Rd6WzojKzn09gb8DH3WV92DKLHyioNgkfPdmB+Xi/yfbVaLVP6V/xhZswODljwSg8ktp4KeA==
   dependencies:
     class-transformer "^0.4.0"
     ioredis "^4.27.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,7 +2126,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ioredis@^4.26.4", "@types/ioredis@^4.26.6":
+"@types/ioredis@^4.26.6":
   version "4.26.6"
   resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.26.6.tgz#7e332d6d24f12d79a1099834ccfa0c169ef667ed"
   integrity sha512-Q9ydXL/5Mot751i7WLCm9OGTj5jlW3XBdkdEW21SkXZ8Y03srbkluFGbM3q8c+vzPW30JOLJ+NsZWHoly0+13A==
@@ -3531,20 +3531,6 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
 
-bullmq@^1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/bullmq/-/bullmq-1.40.1.tgz#2bf4b0c33f9efdd3e10e6b65cf40815beb890dd1"
-  integrity sha512-JQ1hGF8EO0ubOXcq/VAO2NJhuFACApLo+bN+NQ8NIV+VAvcjxvcSqvMl770ynzuVd8LeAjEED6kmWURLMl1hoA==
-  dependencies:
-    "@types/ioredis" "^4.26.4"
-    cron-parser "^2.7.3"
-    get-port "^5.0.0"
-    ioredis "^4.27.5"
-    lodash "^4.17.21"
-    semver "^6.3.0"
-    tslib "^1.10.0"
-    uuid "^8.2.0"
-
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -3871,6 +3857,11 @@ class-transformer@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.3.2.tgz#779ef5f124784324b40f8e927c774bd96cdecd4b"
   integrity sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw==
+
+class-transformer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.4.0.tgz#b52144117b423c516afb44cc1c76dbad31c2165b"
+  integrity sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -4377,14 +4368,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-cron-parser@^2.7.3:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
-  integrity sha512-s4odpheTyydAbTBQepsqd2rNWGa2iV3cyo8g7zbI2QQYGLVsfbhmwukayS1XHppe02Oy1fg7mg6xoaraVJeEcg==
-  dependencies:
-    is-nan "^1.3.0"
-    moment-timezone "^0.5.31"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -5868,11 +5851,6 @@ get-port@^4.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
-get-port@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
-  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -6676,22 +6654,6 @@ inversify@^5.0.1:
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
   integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
 
-ioredis@^4.27.5:
-  version "4.27.6"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.27.6.tgz#a53d427d3fe75fbd10ed7ad150ce00559df8dcf8"
-  integrity sha512-6W3ZHMbpCa8ByMyC1LJGOi7P2WiOKP9B3resoZOVLDhi+6dDBOW+KNsRq3yI36Hmnb2sifCxHX+YSarTeXh48A==
-  dependencies:
-    cluster-key-slot "^1.1.0"
-    debug "^4.3.1"
-    denque "^1.1.0"
-    lodash.defaults "^4.2.0"
-    lodash.flatten "^4.4.0"
-    p-map "^2.1.0"
-    redis-commands "1.7.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.1.0"
-
 ioredis@^4.27.7:
   version "4.27.7"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.27.7.tgz#11bf2947e23a0e8055931afa7c2da89fc48c8ff3"
@@ -6939,14 +6901,6 @@ is-installed-globally@^0.3.1:
   dependencies:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
-
-is-nan@^1.3.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -8491,22 +8445,21 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+modest-queue@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/modest-queue/-/modest-queue-0.0.6.tgz#263e74599b3d57d8e6b1451bd953a2721ecf69f7"
+  integrity sha512-TMz0+8MQNVzad6l6+YHF2mSzvuDRvzf0n6Ph8w95CrfvbAQMDuobOeGe4FW236Qw5qJDa2uEXojjGDJXqUKurw==
+  dependencies:
+    class-transformer "^0.4.0"
+    ioredis "^4.27.7"
+    reflect-metadata "^0.1.13"
+    tslib "^1.9.3"
+    uuid "^3.3.2"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment-timezone@^0.5.31:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -11884,7 +11837,7 @@ ts-jest@^26.1.1:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -12303,7 +12256,7 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.2.0, uuid@^8.3.0:
+uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Proposing moving from bullmq to a much simpler queue implementation: https://gitlab.com/ersutton/modest-queue

had some issues with bullmq when processing messages, when you set a job to be completed, it would automatically pop the next message to be processed off the queue - which would have made the implementation in this library messy.

This MR
* migrates to modest-queue
* publishes messages to any queue that has stated that it wants to know about a certain message

Tests pass:
![image](https://user-images.githubusercontent.com/18492498/130465318-7d91502b-54fa-46f2-a00c-8a92e808f7f8.png)
