### PR TITLE
Fix sendonly initialization

### DIFF
--- a/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
+++ b/packages/bus-core/src/application-bootstrap/application-bootstrap.ts
@@ -26,6 +26,7 @@ export class ApplicationBootstrap {
     }
     this.logger.info('Initializing bus application...')
     this.handlerRegistry.bindHandlersToContainer(container)
+    await this.connectTransport()
     await this.initializeTransport()
     await this.bus.start()
     this.isInitialized = true
@@ -40,7 +41,7 @@ export class ApplicationBootstrap {
       throw new Error('A send-only bus cannot have registered handlers')
     }
     this.logger.info('Initializing send only bus application...')
-    await this.initializeTransport()
+    await this.connectTransport()
     this.isInitialized = true
     this.logger.info('Send only bus application initialized')
   }
@@ -56,6 +57,10 @@ export class ApplicationBootstrap {
 
     if (this.transport.dispose) {
       await this.transport.dispose()
+    }
+
+    if (this.transport.disconnect) {
+      await this.transport.disconnect()
     }
 
     this.logger.info('Bus application disposed')
@@ -81,6 +86,12 @@ export class ApplicationBootstrap {
       prototype.$message,
       prototype.$topicIdentifier
     )
+  }
+
+  private async connectTransport (): Promise<void> {
+    if (this.transport.connect) {
+      await this.transport.connect()
+    }
   }
 
   private async initializeTransport (): Promise<void> {

--- a/packages/bus-core/src/transport/transport.ts
+++ b/packages/bus-core/src/transport/transport.ts
@@ -53,6 +53,18 @@ export interface Transport<TransportMessageType = {}> {
   returnMessage (message: TransportMessage<TransportMessageType>): Promise<void>
 
   /**
+   * An optional function that will be called on startup. This gives a chance for the transport
+   * to establish any connections to the underlying infrastructure.
+   */
+  connect? (): Promise<void>
+
+  /**
+   * An optional function that will be called on shutdown. This gives a chance for the transport
+   * to close any connections to the underlying infrastructure.
+   */
+  disconnect? (): Promise<void>
+
+  /**
    * An optional function that will be called when the service bus is starting. This is an
    * opportunity for the transport to see what messages need to be handled so that subscriptions
    * to the topics can be created.
@@ -64,4 +76,5 @@ export interface Transport<TransportMessageType = {}> {
    * opportunity for the transport to close out any open requests to fetch messages etc.
    */
   dispose? (): Promise<void>
+
 }

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -36,15 +36,20 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     this.maxRetries = configuration.maxRetries ?? DEFAULT_MAX_RETRIES
   }
 
-  async initialize (): Promise<void> {
-    this.logger.info('Initializing RabbitMQ transport')
+  async connect (): Promise<void> {
+    this.logger.info('Connecting to RabbitMQ...')
     this.connection = await this.connectionFactory()
     this.channel = await this.connection.createChannel()
+    this.logger.info('Connected to RabbitMQ')
+  }
+
+  async initialize (): Promise<void> {
+    this.logger.info('Initializing RabbitMQ transport')
     await this.bindExchangesToQueue()
     this.logger.info('RabbitMQ transport initialized')
   }
 
-  async dispose (): Promise<void> {
+  async disconnect (): Promise<void> {
     await this.channel.close()
     await this.connection.close()
   }

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -31,8 +31,8 @@ export interface RedisTransportConfiguration {
 
   /**
    * The scheduler is a worker that checks messages if any messages have exceeded the
-   * visibility timeout. If they have, the are re added to the queue. It might be more performant to have only a few of these
-   * running.
+   * visibility timeout. If they have, the are re added to the queue.
+   * It might be more performant to have only a few of these running.
    * @default true
    */
   withScheduler?: boolean


### PR DESCRIPTION
`.initializeSendOnly()` was trying to create app & dlqs. In reality it should only do enough setup to allow the library to connect and send a message only. 

This fix introduces `connect()` `disconnect()` to the transport definition so that the transport implementation can be more specific around how it starts up.