### PR TITLE
bus-redis - add the ability to configure the subscriptionsKeyPrefix

### DIFF
--- a/packages/bus-redis/README.md
+++ b/packages/bus-redis/README.md
@@ -43,7 +43,7 @@ The Redis transport has the following configuration:
 * **connectionString** *(required)* A redis formatted connection string that's used to connect to the Redis instance
 * **maxRetries** *(optional)* The number of attempts to retry failed messages before they're routed to the dead letter queue. *Default: 10*
 * **visibilityTimeout** *(optional)* The time taken before a message has been deemed to have failed or stalled. Once this time has been exceeded the message will be re-added to queue. *Default: 30000*
-* **withScheduler** *(optional)* The scheduler is a worker that checks messages if any messages have exceeded the visibility timeout. If they have, the are re added to the queue. It might be more performant to have only a few of these running. *Default: true*
+* **subscriptionsKeyPrefix** *(optional)* Different queues may want to be aware of the same event being sent on the bus. We need to store a set of queue names that are interested in events being published on the bus and where better than redis at a certain key. *Default: 'node-ts:bus-redis:subscriptions:'*
 ## Development
 
 Local development can be done with the aid of docker to run the required infrastructure. To do so, run:

--- a/packages/bus-redis/src/redis-transport-configuration.ts
+++ b/packages/bus-redis/src/redis-transport-configuration.ts
@@ -37,4 +37,13 @@ export interface RedisTransportConfiguration {
    */
   withScheduler?: boolean
 
+  /**
+   * Different queues may want to be aware of the same event being sent on the bus
+   * We need to store a set of queue names that are interested in events being published on the bus
+   * and where better than redis at a certain key.
+   *
+   * @default 'node-ts:bus-redis:subscriptions:'
+   */
+  subscriptionsKeyPrefix?: string
+
 }

--- a/packages/bus-redis/src/redis-transport.ts
+++ b/packages/bus-redis/src/redis-transport.ts
@@ -50,7 +50,7 @@ export class RedisTransport implements Transport<QueueMessage> {
       private readonly handlerRegistry: HandlerRegistry
   ) {
     this.maxRetries = configuration.maxRetries ?? DEFAULT_MAX_RETRIES
-    this.subscriptionsKeyPrefix = 'node-ts:bus-redis:subscriptions:'
+    this.subscriptionsKeyPrefix = configuration.subscriptionsKeyPrefix ?? 'node-ts:bus-redis:subscriptions:'
   }
 
   async connect (): Promise<void> {


### PR DESCRIPTION
For proper separation of test environment and local environment, and also to support multiple applications running on the same redis instance, it would be good to have the prefix be configurable.

All tests still pass, and this is a backwards compatible change.