### PR TITLE
Fix publish on rabbit

### DIFF
--- a/packages/bus-rabbitmq/package.json
+++ b/packages/bus-rabbitmq/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/amqplib": "^0.5.11",
     "@node-ts/bus-messages": "^1.0.0",
     "amqplib": "^0.6.0",
     "tslib": "^1.9.3",
@@ -26,7 +27,6 @@
     "@node-ts/bus-core": "^1.0.0",
     "@node-ts/bus-test": "^0.0.2",
     "@node-ts/code-standards": "^0.0.10",
-    "@types/amqplib": "^0.5.11",
     "@types/faker": "^4.1.5",
     "@types/uuid": "^3.4.4",
     "faker": "^4.1.0",

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.integration.ts
@@ -3,7 +3,7 @@ import { Connection, Channel, connect, ConsumeMessage } from 'amqplib'
 import { DefaultHandlerRegistry, JsonSerializer, MessageSerializer } from '@node-ts/bus-core'
 import { RabbitMqTransportConfiguration } from './rabbitmq-transport-configuration'
 import { Message, MessageAttributeMap, MessageAttributes } from '@node-ts/bus-messages'
-import uuid from 'uuid'
+import * as uuid from 'uuid'
 import { transportTests, TestSystemMessage } from '@node-ts/bus-test'
 
 const configuration: RabbitMqTransportConfiguration = {

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -14,7 +14,7 @@ import {
 } from '@node-ts/bus-core'
 import { Connection, Channel, Message as RabbitMqMessage, GetMessage, connect } from 'amqplib'
 import { RabbitMqTransportConfiguration } from './rabbitmq-transport-configuration'
-import uuid from 'uuid'
+import * as uuid from 'uuid'
 
 export const DEFAULT_MAX_RETRIES = 10
 


### PR DESCRIPTION
Fixes #141 - a bug on `.publishMessage` in the rabbitmq transport that was reporting

![image](https://user-images.githubusercontent.com/6031613/136672517-ae826999-f40c-4251-93a5-1573c9d92aed.png)

Bug was due to an incorrect import and verified in https://github.com/node-ts/bus-starter