### PR TITLE
Disconnect transport on dispose

### DIFF
--- a/packages/bus-core/src/service-bus/bus-instance.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.ts
@@ -157,6 +157,9 @@ export class BusInstance {
     if (![BusState.Stopped, BusState.Stopped].includes(this.state)) {
       await this.stop()
     }
+    if (this.transport.disconnect) {
+      await this.transport.disconnect()
+    }
     if (this.transport.dispose) {
       await this.transport.dispose()
     }


### PR DESCRIPTION
Fixes a bug where transports that implement `.disconnect()` aren't closing out connections properly