### PR TITLE
Fix: Memory queue fail deletes other messages

### DIFF
--- a/packages/bus-core/src/index.ts
+++ b/packages/bus-core/src/index.ts
@@ -1,5 +1,3 @@
-export * from './service-bus/bus'
-export * from './service-bus/bus-instance'
 export {
   Transport,
   TransportMessage,
@@ -13,3 +11,4 @@ export * from './workflow'
 export * from './error'
 export * from './container'
 export * from './logger'
+export * from './service-bus'


### PR DESCRIPTION
Fix for #162 

Because `.fail()` internally deletes the message, when the handler finishes it will also try to delete the message by its new index (-1). Because the delete operation is a splice from the array; any messages between -1 and 1 are deleted.

Other transports don't have this issue since the deletion is made using the receiptId/messageId

