### PR TITLE
#126 - Use promise.allSettled() during message dispatch

### DIFF
--- a/packages/bus-core/src/container/container-adapter.spec.ts
+++ b/packages/bus-core/src/container/container-adapter.spec.ts
@@ -5,7 +5,7 @@ import { MessageLogger } from '../test/test-event-handler'
 import { ClassConstructor, sleep } from '../util'
 import { TestEvent, TestEvent2 } from '../test'
 import { ClassHandlerNotResolved, ContainerNotRegistered } from '../error'
-import { Handler } from '../handler'
+import { Handler, HandlerDispatchRejected } from '../handler'
 
 class UnregisteredClassHandler implements Handler<TestEvent2> {
   messageType = TestEvent2
@@ -75,8 +75,10 @@ describe('ContainerAdapter', () => {
     describe('and a handler is not registered', () => {
       it('should throw a ClassHandlerNotResolved error', async () => {
         const onError = waitForError(bus, error => {
-          expect(error).toBeInstanceOf(ClassHandlerNotResolved)
-          const classHandlerNotResolved = error as ClassHandlerNotResolved
+          expect(error).toBeInstanceOf(HandlerDispatchRejected)
+          const baseError = error as HandlerDispatchRejected
+          expect(baseError.rejections[0]).toBeInstanceOf(ClassHandlerNotResolved)
+          const classHandlerNotResolved = baseError.rejections[0] as ClassHandlerNotResolved
           expect(classHandlerNotResolved.reason).toEqual('Container failed to resolve an instance.')
         })
         await bus.publish(new TestEvent2())

--- a/packages/bus-core/src/handler/error/handler-dispatch-rejected.ts
+++ b/packages/bus-core/src/handler/error/handler-dispatch-rejected.ts
@@ -1,0 +1,10 @@
+export class HandlerDispatchRejected extends Error {
+  constructor (
+    readonly rejections: Error[]
+  ) {
+    super(`Processing of a message has failed in at least one handler and will be sent back to the queue for retry.`)
+
+    // tslint:disable-next-line:no-unsafe-any
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/packages/bus-core/src/handler/error/handler-dispatch-rejected.ts
+++ b/packages/bus-core/src/handler/error/handler-dispatch-rejected.ts
@@ -1,4 +1,7 @@
 export class HandlerDispatchRejected extends Error {
+  /**
+   * @param rejections All errors thrown by handlers for the message
+   */
   constructor (
     readonly rejections: Error[]
   ) {

--- a/packages/bus-core/src/handler/error/index.ts
+++ b/packages/bus-core/src/handler/error/index.ts
@@ -1,2 +1,3 @@
 export * from './handler-already-registered'
 export * from './system-message-missing-resolver'
+export * from './handler-dispatch-rejected'

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -155,7 +155,7 @@ export class SqsTransport implements Transport<SQS.Message> {
         'Received more than the expected number of messages',
         { expected: 1, received: result.Messages.length }
       )
-      await Promise.all(
+      await Promise.allSettled(
         result.Messages
           .map(async message => this.makeMessageVisible(message))
       )


### PR DESCRIPTION
Closes #126 

This uses `promise.allSettled()` instead of `promise.all()` when dispatching the same message to multiple handlers on the same instance. This is done as there is no coupling between handlers and failure in one shouldn't affect processing in another.

Note that this still throws all errors from the dispatch that are now inside the `HandlerDispatchRejected` error in the `reasons` attribute.

The  message will still be retried, so it's still important as always to ensure message handling is idempotent.