### PR TITLE
Use container to get workflows

### DIFF
--- a/packages/bus-core/src/workflow/registry/workflow-registry.ts
+++ b/packages/bus-core/src/workflow/registry/workflow-registry.ts
@@ -84,7 +84,10 @@ export class WorkflowRegistry {
     for (const WorkflowCtor of this.workflowRegistry) {
       this.logger.debug('Initializing workflow', { workflow: WorkflowCtor.prototype.constructor.name })
 
-      const workflowInstance = new WorkflowCtor()
+      const workflowInstance = container
+        ? container.get(WorkflowCtor)
+        : new WorkflowCtor()
+
       const mapper = new WorkflowMapper(WorkflowCtor)
       workflowInstance.configureWorkflow(mapper)
 


### PR DESCRIPTION
Closes #157 

When a `ContainerAdapter` is provided, it should be used when getting workflow instances to dispatch messages to.  Depending on the IoC container, fetching a Workflow instance that hasn't been registered with the container should throw a descriptive error and encourage the consumer to register it.

When a `ContainerAdapter` is not provided, the system should fallback to manually constructing the workflow