### PR TITLE
157 - addendum 

### DIFF
--- a/packages/bus-core/src/workflow/registry/workflow-registry.spec.ts
+++ b/packages/bus-core/src/workflow/registry/workflow-registry.spec.ts
@@ -1,0 +1,49 @@
+import { CoreDependencies } from '../../util'
+import { TestWorkflow } from '../test/test-workflow'
+import { WorkflowRegistry } from './workflow-registry'
+import { IMock, Mock, Times } from 'typemoq'
+import { InMemoryPersistence } from '../persistence'
+import { DefaultHandlerRegistry } from '../../handler'
+import { ContainerAdapter } from '../../container'
+import { BusInstance } from '../../service-bus'
+import { DebugLogger } from '../../logger'
+
+describe('WorkflowRegistry', () => {
+  describe('when initializing', () => {
+    let sut: WorkflowRegistry
+    let persistence = Mock.ofType(InMemoryPersistence)
+
+    beforeEach(() => {
+      sut = new WorkflowRegistry()
+      sut.register(TestWorkflow)
+      sut.prepare({
+          loggerFactory: (name: string) => new DebugLogger(name)
+        } as unknown as CoreDependencies,
+        persistence.object
+      )
+    })
+
+    describe('without a container', () => {
+      it('should construct workflow instances', async () => {
+        await sut.initialize(new DefaultHandlerRegistry(), undefined)
+      })
+    })
+
+    describe('with a container', () => {
+      let container: IMock<ContainerAdapter>
+
+      beforeEach(() => {
+        container = Mock.ofType<ContainerAdapter>()
+        container
+          .setup(c => c.get(TestWorkflow))
+          .returns(() => new TestWorkflow(Mock.ofType<BusInstance>().object))
+          .verifiable(Times.once())
+      })
+
+      it('should fetch workflows from the container', async () => {
+        await sut.initialize(new DefaultHandlerRegistry(), container.object)
+        container.verifyAll()
+      })
+    })
+  })
+})

--- a/packages/bus-core/src/workflow/registry/workflow-registry.ts
+++ b/packages/bus-core/src/workflow/registry/workflow-registry.ts
@@ -84,7 +84,10 @@ export class WorkflowRegistry {
     for (const WorkflowCtor of this.workflowRegistry) {
       this.logger.debug('Initializing workflow', { workflow: WorkflowCtor.prototype.constructor.name })
 
-      const workflowInstance = new WorkflowCtor()
+      const workflowInstance = container
+        ? container.get(WorkflowCtor)
+        : new WorkflowCtor()
+
       const mapper = new WorkflowMapper(WorkflowCtor)
       workflowInstance.configureWorkflow(mapper)
 


### PR DESCRIPTION
Closes #157 

A continuation of #169 

When a `ContainerAdapter` is provided, it should be used when getting workflow instances to dispatch messages to.  Depending on the IoC container, fetching a Workflow instance that hasn't been registered with the container should throw a descriptive error and encourage the consumer to register it.

When a `ContainerAdapter` is not provided, the system should fallback to manually constructing the workflow