### PR TITLE
0.x - logger-core semver updates in peerDependencies

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "@node-ts/logger-core": "^0.0.17",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1"
   },
   "keywords": [

--- a/packages/bus-postgres/package.json
+++ b/packages/bus-postgres/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@node-ts/bus-workflow": "^0.1.10",
     "@node-ts/code-standards": "^0.0.10",
-    "@node-ts/logger-core": "^0.0.13",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   },

--- a/packages/bus-rabbitmq/package.json
+++ b/packages/bus-rabbitmq/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@node-ts/bus-core": "^0.6.6",
-    "@node-ts/logger-core": "^0.0.13",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   },

--- a/packages/bus-redis/package.json
+++ b/packages/bus-redis/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@node-ts/bus-core": "^0.6.6",
-    "@node-ts/logger-core": "^0.0.13",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   },

--- a/packages/bus-sqs/package.json
+++ b/packages/bus-sqs/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@node-ts/bus-core": "^0.6.6",
-    "@node-ts/logger-core": "^0.0.13",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   },

--- a/packages/bus-workflow/package.json
+++ b/packages/bus-workflow/package.json
@@ -31,8 +31,8 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "@node-ts/bus-core": "^0.4.6",
-    "@node-ts/logger-core": "^0.0.17",
+    "@node-ts/bus-core": "^0.6.0",
+    "@node-ts/logger-core": "^0.1.0",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   },


### PR DESCRIPTION
After a recent update to npm 7, we saw several errors fetching peer dependencies.  Updating the semver strings repaired these errors.  I have updated my fork of 0.x to include these updated semver strings for logger-core and bus-core in several packages. 

We still see a peerDependency issue in logger-core itself but it seems logger-core is a private repo, we would like to have a similar fix applied there. 