### PR TITLE
#175  - Fix high cpu for rabbitmq consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -323,11 +323,6 @@ Session.vim
 pyvenv.cfg
 pip-selfcheck.json
 
-#####=== VisualStudioCode ===#####
-.settings
-.vscode/
-
-
 #####=== Windows ===#####
 # Windows image file caches
 Thumbs.db

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "configurations": [
+    {
+      /*
+        Runs the test in the active window in watch mode, allowing for debug breakpoints to be hit.
+        Breakpoints can be added anywhere up and down the stack, including in node_modules.
+      */
+      "name": "Debug test",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "pnpm",
+      "args": ["run", "test:watch", "${file}", "--", "--runInBand"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#93e6fc",
+        "activityBar.activeBorder": "#fa45d4",
+        "activityBar.background": "#93e6fc",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#fa45d4",
+        "activityBarBadge.foreground": "#15202b",
+        "statusBar.background": "#61dafb",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#2fcefa",
+        "titleBar.activeBackground": "#61dafb",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#61dafb99",
+        "titleBar.inactiveForeground": "#15202b99",
+        "sash.hoverBorder": "#93e6fc",
+        "statusBarItem.remoteBackground": "#61dafb",
+        "statusBarItem.remoteForeground": "#15202b"
+    },
+    "peacock.color": "#61dafb"
+}

--- a/packages/bus-core/src/index.ts
+++ b/packages/bus-core/src/index.ts
@@ -2,6 +2,7 @@ export {
   Transport,
   TransportMessage,
   TransportConfiguration,
+  TransportConnectionOptions,
   DEFAULT_DEAD_LETTER_QUEUE_NAME
 } from './transport'
 export * from './handler'

--- a/packages/bus-core/src/service-bus/bus-configuration.ts
+++ b/packages/bus-core/src/service-bus/bus-configuration.ts
@@ -79,7 +79,9 @@ export class BusConfiguration {
     const transport: Transport = this.configuredTransport || new MemoryQueue()
     transport.prepare(coreDependencies)
     if (transport.connect) {
-      await transport.connect()
+      await transport.connect({
+        concurrency: this.concurrency
+      })
     }
     if (!sendOnly && transport.initialize) {
       await transport.initialize(this.handlerRegistry)

--- a/packages/bus-core/src/service-bus/bus-instance.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.ts
@@ -113,6 +113,10 @@ export class BusInstance {
     this.logger.info('Bus starting...')
     messageHandlingContext.enable()
 
+    if(this.transport.start) {
+      await this.transport.start()
+    }
+
     this.internalState = BusState.Started
     for (var i = 0; i < this.concurrency; i++) {
       setTimeout(async () => this.applicationLoop(), 0)
@@ -138,6 +142,9 @@ export class BusInstance {
     }
     this.internalState = BusState.Stopping
     this.logger.info('Bus stopping...')
+    if (this.transport.stop) {
+      await this.transport.stop()
+    }
 
     while (this.runningWorkerCount > 0) {
       await sleep(10)

--- a/packages/bus-core/src/transport/transport.ts
+++ b/packages/bus-core/src/transport/transport.ts
@@ -3,6 +3,10 @@ import { CoreDependencies } from '../util'
 import { HandlerRegistry } from '../handler'
 import { TransportMessage } from './transport-message'
 
+export interface TransportConnectionOptions {
+  concurrency: number
+}
+
 /**
  * A transport adapter interface that enables the service bus to use a messaging technology.
  */
@@ -72,13 +76,23 @@ export interface Transport<TransportMessageType = {}> {
    * An optional function that will be called on startup. This gives a chance for the transport
    * to establish any connections to the underlying infrastructure.
    */
-  connect? (): Promise<void>
+  connect? (options: TransportConnectionOptions): Promise<void>
 
   /**
    * An optional function that will be called on shutdown. This gives a chance for the transport
    * to close any connections to the underlying infrastructure.
    */
   disconnect? (): Promise<void>
+
+  /**
+   * An optional method called on the transport when it should start consuming messages.
+   */
+  start? (): Promise<void>
+
+  /**
+   * An optional method called on the transport when it should no longer consume messages.
+   */
+  stop? (): Promise<void>
 
   /**
    * An optional function that will be called when the service bus is starting. This is an

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -131,10 +131,10 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
 
       // No messages immediately available, so wait for one to be received
       const messageConsumedCallback = () => {
-        const message = this.consumptionQueue.shift()
-        if (message) {
+        const maybeMessage = this.consumptionQueue.shift()
+        if (maybeMessage) {
           unsubscribe()
-          resolve(message)
+          resolve(maybeMessage)
         }
       }
 

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -10,13 +10,20 @@ import {
   TransportMessage,
   DEFAULT_DEAD_LETTER_QUEUE_NAME,
   CoreDependencies,
-  Logger
+  Logger,
+  TransportConnectionOptions
 } from '@node-ts/bus-core'
-import { Connection, Channel, Message as RabbitMqMessage, GetMessage, connect } from 'amqplib'
+import { Connection, Channel, Message as RabbitMqMessage, GetMessage, connect, ConsumeMessage } from 'amqplib'
 import { RabbitMqTransportConfiguration } from './rabbitmq-transport-configuration'
 import * as uuid from 'uuid'
+import { EventEmitter } from 'events'
 
 export const DEFAULT_MAX_RETRIES = 10
+
+enum ConsumptionQueueEvent {
+  Pushed = 'pushed',
+  Stopped = 'stopped'
+}
 
 /**
  * A RabbitMQ transport adapter for @node-ts/bus.
@@ -36,6 +43,9 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
   private coreDependencies: CoreDependencies
   private logger: Logger
 
+  private consumptionQueue: ConsumeMessage[] = []
+  private consumptionQueueEvents = new EventEmitter()
+
   constructor (
     private readonly configuration: RabbitMqTransportConfiguration
   ) {
@@ -51,10 +61,11 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     this.logger = coreDependencies.loggerFactory('@node-ts/bus-rabbitmq:rabbitmq-transport')
   }
 
-  async connect (): Promise<void> {
+  async connect (options: TransportConnectionOptions): Promise<void> {
     this.logger.info('Connecting to RabbitMQ...')
     this.connection = await connect(this.configuration.connectionString)
     this.channel = await this.connection.createChannel()
+    this.channel.prefetch(options.concurrency)
     this.logger.info('Connected to RabbitMQ')
   }
 
@@ -91,9 +102,57 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     )
   }
 
+  async start (): Promise<void> {
+    await this.channel.consume(
+      this.configuration.queueName,
+      (msg: ConsumeMessage | null) => {
+        if (!msg) {
+          return
+        }
+        this.consumptionQueue.push(msg)
+        this.consumptionQueueEvents.emit(ConsumptionQueueEvent.Pushed)
+      },
+      { noAck: false }
+    )
+  }
+
+  async stop (): Promise<void> {
+    // Tell the .consume() subscription to exit
+    this.consumptionQueueEvents.emit(ConsumptionQueueEvent.Stopped)
+  }
+
   async readNextMessage (): Promise<TransportMessage<RabbitMqMessage> | undefined> {
-    const rabbitMessage = await this.channel.get(this.configuration.queueName, { noAck: false })
-    if (rabbitMessage === false) {
+    const rabbitMessage = await new Promise<ConsumeMessage | undefined>(resolve => {
+      const message = this.consumptionQueue.shift()
+      if (message) {
+        resolve(message)
+        return
+      }
+
+      // No messages immediately available, so wait for one to be received
+      const messageConsumedCallback = () => {
+        const message = this.consumptionQueue.shift()
+        if (message) {
+          unsubscribe()
+          resolve(message)
+        }
+      }
+
+      const messageStoppedCallback = () => {
+        unsubscribe()
+        resolve(undefined)
+      }
+
+      const unsubscribe = () => {
+        this.consumptionQueueEvents.off(ConsumptionQueueEvent.Pushed, messageConsumedCallback)
+        this.consumptionQueueEvents.off(ConsumptionQueueEvent.Stopped, messageStoppedCallback)
+      }
+
+      this.consumptionQueueEvents.on(ConsumptionQueueEvent.Pushed, messageConsumedCallback)
+      this.consumptionQueueEvents.on(ConsumptionQueueEvent.Stopped, messageStoppedCallback)
+    })
+
+    if (!rabbitMessage) {
       return undefined
     }
     const payloadStr = rabbitMessage.content.toString('utf8')

--- a/packages/bus-test/package.json
+++ b/packages/bus-test/package.json
@@ -3,13 +3,10 @@
   "version": "0.0.16",
   "description": "A dev-dependency package used to test transport implementations.",
   "homepage": "https://github.com/node-ts/bus#readme",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
   "license": "MIT",
   "repository": "github:node-ts/bus.git",
   "scripts": {
-    "build": "tsc --project tsconfig.json --declaration",
-    "build:watch": "yarn run build --incremental --watch --preserveWatchOutput",
     "lint": "tslint --project tsconfig.json 'src/**/*.ts'",
     "lint:fix": "yarn lint --fix"
   },


### PR DESCRIPTION
This is a fix for #175 where a consumer of an empty rabbitmq queue will see high CPU. This is due to an implementation that relied on amqplib's `channel.get()` that returns immediately regardless if a message is queued or not. As a result this was being called repeatedly causing the high CPU spin (evidenced by less CPU when a .sleep() was added)

This change uses `.consume()` instead which is callback based and only triggers when a message is available for consumption. As a result there is no repeated spinning waiting for a message.