### PR TITLE
Upgrade class-transformer to 0.5.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
         "titleBar.inactiveForeground": "#15202b99",
         "sash.hoverBorder": "#93e6fc",
         "statusBarItem.remoteBackground": "#61dafb",
-        "statusBarItem.remoteForeground": "#15202b"
+        "statusBarItem.remoteForeground": "#15202b",
+        "commandCenter.border": "#15202b99"
     },
     "peacock.color": "#61dafb"
 }

--- a/packages/bus-class-serializer/package.json
+++ b/packages/bus-class-serializer/package.json
@@ -17,12 +17,12 @@
   },
   "devDependencies": {
     "@node-ts/bus-core": "^1.0.13",
-    "class-transformer": "^0.3.1",
+    "class-transformer": "^0.5.1",
     "reflect-metadata": "^0.1.13"
   },
   "peerDependencies": {
     "@node-ts/bus-core": "^1.0.0-alpha.0",
-    "class-transformer": "^0.3.1"
+    "class-transformer": "^0.5.1"
   },
   "keywords": [
     "serializer",

--- a/packages/bus-class-serializer/src/class-serializer.ts
+++ b/packages/bus-class-serializer/src/class-serializer.ts
@@ -1,5 +1,5 @@
 import { Serializer, ClassConstructor } from '@node-ts/bus-core'
-import { instanceToPlain, plainToClass, serialize, deserialize } from 'class-transformer'
+import { instanceToPlain, plainToInstance, serialize, deserialize } from 'class-transformer'
 
 /**
  * A JSON-based serializer that uses `class-transformer` to transform to and from
@@ -24,6 +24,6 @@ export class ClassSerializer implements Serializer {
   }
 
   toClass<T extends object> (obj: object, classConstructor: ClassConstructor<T>): T {
-    return plainToClass(classConstructor, obj)
+    return plainToInstance(classConstructor, obj)
   }
 }

--- a/packages/bus-class-serializer/src/class-serializer.ts
+++ b/packages/bus-class-serializer/src/class-serializer.ts
@@ -1,5 +1,5 @@
 import { Serializer, ClassConstructor } from '@node-ts/bus-core'
-import { classToPlain, plainToClass, serialize, deserialize } from 'class-transformer'
+import { instanceToPlain, plainToClass, serialize, deserialize } from 'class-transformer'
 
 /**
  * A JSON-based serializer that uses `class-transformer` to transform to and from
@@ -20,7 +20,7 @@ export class ClassSerializer implements Serializer {
   }
 
   toPlain<T extends object> (obj: T): object {
-    return classToPlain(obj)
+    return instanceToPlain(obj)
   }
 
   toClass<T extends object> (obj: object, classConstructor: ClassConstructor<T>): T {

--- a/packages/bus-sqs/package.json
+++ b/packages/bus-sqs/package.json
@@ -29,7 +29,7 @@
     "@types/amqplib": "^0.5.11",
     "@types/faker": "^4.1.5",
     "@types/uuid": "^3.4.4",
-    "class-transformer": "^0.3.1",
+    "class-transformer": "^0.5.1",
     "faker": "^4.1.0",
     "reflect-metadata": "^0.1.13",
     "typemoq": "^2.1.0",

--- a/packages/bus-test/package.json
+++ b/packages/bus-test/package.json
@@ -22,7 +22,7 @@
     "@node-ts/code-standards": "^0.0.10",
     "@types/faker": "^5.5.7",
     "@types/node": "^14.14.31",
-    "class-transformer": "^0.4.0",
+    "class-transformer": "^0.5.1",
     "faker": "^5.5.3",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,15 +2327,10 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-class-transformer@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.3.2.tgz#779ef5f124784324b40f8e927c774bd96cdecd4b"
-  integrity sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw==
-
-class-transformer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.4.0.tgz#b52144117b423c516afb44cc1c76dbad31c2165b"
-  integrity sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
This PR bumps the `class-transformer` dependency from 0.3.1 -> 0.5.1. 

0.3.2, 0.4.0, 0.50 and 0.51 all had "breaking changes", although they are minimal: https://github.com/typestack/class-transformer/blob/develop/CHANGELOG.md

The objective is to suppress warnings in consuming project build output, fixed in 0.3.2:

```bash
WARNING in ../../node_modules/.pnpm/class-transformer@0.3.1/node_modules/class-transformer/storage.js
Module Warning (from ../../node_modules/.pnpm/source-map-loader@3.0.1_webpack@5.74.0/node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/x-project/node_modules/.pnpm/class-transformer@0.3.1/node_modules/src/storage.ts' file: Error: ENOENT: no such file or directory, open '/x-project/node_modules/.pnpm/class-transformer@0.3.1/node_modules/src/storage.ts'
```