### PR TITLE
Support async resolvers in container.

### DIFF
--- a/packages/bus-core/src/container/container-adapter.ts
+++ b/packages/bus-core/src/container/container-adapter.ts
@@ -10,5 +10,5 @@ export interface ContainerAdapter {
    * @param type Type of the class to fetch an instance for
    * @example get(MessageHandler)
    */
-  get <T>(type: ClassConstructor<T>): T
+  get <T>(type: ClassConstructor<T>): T| Promise<T>
 }

--- a/packages/bus-core/src/service-bus/bus-configuration.ts
+++ b/packages/bus-core/src/service-bus/bus-configuration.ts
@@ -251,7 +251,7 @@ export class BusConfiguration {
    * and workflows.
    * @param container An adapter to an existing DI container to fetch class instances from
    */
-  withContainer (container: { get <T>(type: ClassConstructor<T>): T }): this {
+  withContainer (container: { get <T>(type: ClassConstructor<T>): T | Promise<T> }): this {
     this.container = container
     return this
   }

--- a/packages/bus-core/src/service-bus/bus-instance.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.ts
@@ -296,7 +296,12 @@ export class BusInstance {
 
       let handlerInstance: Handler<Message> | undefined
       try {
-        handlerInstance = this.coreDependencies.container!.get(classHandler)
+        const handlerInstanceFromContainer = this.coreDependencies.container!.get(classHandler);
+        if(handlerInstanceFromContainer instanceof Promise) {
+          handlerInstance = await handlerInstanceFromContainer;
+        } else{
+          handlerInstance =  handlerInstanceFromContainer;
+        }  
         if (!handlerInstance) {
           throw new Error('Container failed to resolve an instance.')
         }

--- a/packages/bus-core/src/workflow/registry/workflow-registry.spec.ts
+++ b/packages/bus-core/src/workflow/registry/workflow-registry.spec.ts
@@ -45,5 +45,21 @@ describe('WorkflowRegistry', () => {
         container.verifyAll()
       })
     })
+    describe('with an async container', () => {
+      let container: IMock<ContainerAdapter>
+
+      beforeEach(() => {
+        container = Mock.ofType<ContainerAdapter>()
+        container
+          .setup(c => c.get(TestWorkflow))
+          .returns(() => Promise.resolve(new TestWorkflow(Mock.ofType<BusInstance>().object)))
+          .verifiable(Times.once())
+      })
+
+      it('should fetch workflows from the container', async () => {
+        await sut.initialize(new DefaultHandlerRegistry(), container.object)
+        container.verifyAll()
+      })
+    })
   })
 })


### PR DESCRIPTION
Since some IoC containers such as loopback and Nest JS are async and returns promises. I have added support of this without breaking the previous code for existing users.  

The applied changes are as below: 
* Update container adapter interface to support both promise and non promises.
* Update the bus configuration and bus instance to handle promises in
* Add new unit tests for async container in adapter and workflow.