### PR TITLE
feat(bus-sqs): use aws-sdk v3, allow passing ARNs

### DIFF
--- a/packages/bus-sqs/package.json
+++ b/packages/bus-sqs/package.json
@@ -17,9 +17,10 @@
     "access": "public"
   },
   "dependencies": {
+    "@aws-sdk/client-sns": "^3.289.0",
+    "@aws-sdk/client-sqs": "^3.289.0",
+    "@aws-sdk/util-arn-parser": "^3.208.0",
     "@node-ts/bus-messages": "^1.0.4",
-    "aws-sdk": "^2.834.0",
-    "tslib": "^1.9.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/bus-sqs/src/queue-resolvers.ts
+++ b/packages/bus-sqs/src/queue-resolvers.ts
@@ -1,4 +1,7 @@
+import { SqsTransportConfiguration } from './sqs-transport-configuration'
+
 const invalidSqsSnsCharacters = new RegExp('[^a-zA-Z0-9_-]', 'g')
+
 export const normalizeMessageName = (messageName: string) =>
   messageName.replace(invalidSqsSnsCharacters, '-')
 
@@ -20,9 +23,11 @@ export const resolveTopicName = (messageName: string) =>
 export const resolveTopicArn = (awsAccountId: string, awsRegion: string, topicName: string) =>
   `arn:aws:sns:${awsRegion}:${awsAccountId}:${topicName}`
 
-export const resolveQueueUrl = (href: string, awsAccountId: string, queueName: string) =>
-  `${href}${awsAccountId}/${queueName}`
+export const resolveQueueUrl = ({ awsAccountId, awsRegion }: SqsTransportConfiguration, queueName: string) =>
+  `https://sqs.${awsRegion}.amazonaws.com/${awsAccountId}/${queueName}`;
+
 export const resolveQueueArn = (awsAccountId: string, awsRegion: string, queueName: string) =>
-  `arn:aws:sqs:${awsRegion}:${awsAccountId}:${queueName}`
-export const resolveDeadLetterQueueName = () =>
-  `dead-letter-queue`
+`arn:aws:sqs:${awsRegion}:${awsAccountId}:${queueName}`
+
+export const resolveDeadLetterQueueName = () => `dlq`
+

--- a/packages/bus-sqs/src/sqs-transport-configuration.ts
+++ b/packages/bus-sqs/src/sqs-transport-configuration.ts
@@ -8,18 +8,29 @@ export interface SqsTransportConfiguration extends TransportConfiguration {
   /**
    * The AWS Account Id of the account where queues and topics will be created
    */
-  awsAccountId: string
+  awsAccountId?: string
 
   /**
    * The AWS region to create queues and topics in
    */
-  awsRegion: string
+  awsRegion?: string
+
+  /**
+   * An optional AWS ARN of the dead letter queue to fail messages to
+   * @default undefined
+   */
+  deadLetterQueueArn?: string;
 
   /**
    * The number of seconds to retain messages in the service and dead letter queues
    * @default 1209600 (14 days)
    */
   messageRetentionPeriod?: number
+
+  /**
+   * The AWS ARN for the target SQS Queue
+   */
+  queueArn?: string
 
   /**
    * An optional custom queue policy to apply to any created SQS queues.

--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -1,14 +1,32 @@
+import { AssertionError } from 'assert';
+
+import {
+  CreateTopicCommand,
+  MessageAttributeValue,
+  PublishCommand,
+  SNSClient,
+  SubscribeCommand
+} from '@aws-sdk/client-sns'
+import {
+  ChangeMessageVisibilityCommand,
+  CreateQueueCommand,
+  DeleteMessageCommand,
+  GetQueueAttributesCommand,
+  Message as SQSMessage,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+  SetQueueAttributesCommand,
+  SQSClient
+} from '@aws-sdk/client-sqs'
+import { parse } from '@aws-sdk/util-arn-parser';
 import { Command, Event, Message, MessageAttributes, MessageAttributeMap } from '@node-ts/bus-messages'
-import { SNS, SQS } from 'aws-sdk'
-import { QueueAttributeMap } from 'aws-sdk/clients/sqs'
 import {
   Transport,
   TransportMessage,
   CoreDependencies,
   Logger
 } from '@node-ts/bus-core'
-import { MessageAttributeValue } from 'aws-sdk/clients/sns'
-import { SqsTransportConfiguration } from './sqs-transport-configuration'
+
 import { generatePolicy } from './generate-policy'
 import {
   normalizeMessageName,
@@ -18,6 +36,9 @@ import {
   resolveTopicArn as defaultResolveTopicArn,
   resolveTopicName as defaultResolveTopicName
 } from './queue-resolvers'
+import { SqsTransportConfiguration } from './sqs-transport-configuration'
+
+type SnsMessageAttributeMap = Record<string, MessageAttributeValue>;
 
 export const MAX_SQS_DELAY_SECONDS: Seconds = 900
 export const MAX_SQS_VISIBILITY_TIMEOUT_SECONDS: Seconds = 43200
@@ -49,7 +70,7 @@ export interface SQSMessageBody {
   MessageAttributes: SqsMessageAttributes
 }
 
-export class SqsTransport implements Transport<SQS.Message> {
+export class SqsTransport implements Transport<SQSMessage> {
 
   /**
    * A registry that tracks what messages have been sent. Sending a message first asserts that the target SNS queue
@@ -76,32 +97,51 @@ export class SqsTransport implements Transport<SQS.Message> {
    */
   constructor (
     private readonly sqsConfiguration: SqsTransportConfiguration,
-    private readonly sqs: SQS = new SQS(),
-    private readonly sns: SNS = new SNS()
+    private readonly sqs: SQSClient,
+    private readonly sns: SNSClient
   ) {
-    this.resolveTopicName = this.sqsConfiguration.resolveTopicName ?? defaultResolveTopicName
-    this.resolveTopicArn = this.sqsConfiguration.resolveTopicArn ?? defaultResolveTopicArn
+    if(!sqsConfiguration.queueArn && !(sqsConfiguration.awsAccountId && sqsConfiguration.awsRegion))
+      throw new AssertionError({ message: 'SqsTransportConfiguration requires one of: awsAccountId and awsRegion and queueName, or queueArn' });
 
-    this.queueUrl = resolveQueueUrl(sqs.endpoint.href, sqsConfiguration.awsAccountId, sqsConfiguration.queueName)
-    this.queueArn = resolveQueueArn(
-      sqsConfiguration.awsAccountId,
-      sqsConfiguration.awsRegion,
-      sqsConfiguration.queueName
-    )
+    this.resolveTopicName = sqsConfiguration.resolveTopicName ?? defaultResolveTopicName
+    this.resolveTopicArn = sqsConfiguration.resolveTopicArn ?? defaultResolveTopicArn
 
-    this.deadLetterQueueName = sqsConfiguration.deadLetterQueueName
+    if (sqsConfiguration.queueArn) {
+      const { accountId, region, resource } = parse(sqsConfiguration.queueArn);
+      sqsConfiguration.awsAccountId = accountId;
+      sqsConfiguration.awsRegion = region;
+      sqsConfiguration.queueName = resource;
+      this.queueArn = sqsConfiguration.queueArn;
+    } else {
+      this.queueArn = resolveQueueArn(
+        sqsConfiguration.awsAccountId!,
+        sqsConfiguration.awsRegion!,
+        sqsConfiguration.queueName!
+      )
+    }
+
+    this.sqs = new SQSClient({ region: sqsConfiguration.awsRegion });
+    this.sns = new SNSClient({ region: sqsConfiguration.awsRegion });
+
+    this.queueUrl = resolveQueueUrl(sqsConfiguration, sqsConfiguration.queueName!)
+
+    if (sqsConfiguration.deadLetterQueueArn) {
+      const { resource } = parse(sqsConfiguration.deadLetterQueueArn);
+      this.deadLetterQueueArn = sqsConfiguration.deadLetterQueueArn;
+      this.deadLetterQueueName = resource;
+    } else {
+      this.deadLetterQueueName = sqsConfiguration.deadLetterQueueName
       ? normalizeMessageName(sqsConfiguration.deadLetterQueueName)
-      : resolveDeadLetterQueueName()
-    this.deadLetterQueueUrl = resolveQueueUrl(
-      sqs.endpoint.href,
-      sqsConfiguration.awsAccountId,
-      this.deadLetterQueueName
-    )
-    this.deadLetterQueueArn = resolveQueueArn(
-      sqsConfiguration.awsAccountId,
-      sqsConfiguration.awsRegion,
-      this.deadLetterQueueName
-    )
+      : resolveDeadLetterQueueName();
+
+      this.deadLetterQueueArn = resolveQueueArn(
+        sqsConfiguration.awsAccountId!,
+        sqsConfiguration.awsRegion!,
+        this.deadLetterQueueName
+      );
+    }
+
+    this.deadLetterQueueUrl = resolveQueueUrl(sqsConfiguration, this.deadLetterQueueName)
   }
 
   prepare (coreDependencies: CoreDependencies): void {
@@ -117,7 +157,7 @@ export class SqsTransport implements Transport<SQS.Message> {
     await this.publishMessage(command, messageAttributes)
   }
 
-  async fail (transportMessage: TransportMessage<SQS.Message>): Promise<void> {
+  async fail (transportMessage: TransportMessage<SQSMessage>): Promise<void> {
     /*
       SQS doesn't support forwarding a message to another queue. This approach will copy the message to the dead letter
       queue and then delete it from the source queue. This changes its message id and other attributes such as receive
@@ -127,24 +167,27 @@ export class SqsTransport implements Transport<SQS.Message> {
       the redrive policy kicks in. This approach was not preferred due to the additional number of handles that would
       need to happen.
     */
-    await this.sqs.sendMessage({
+    const command = new SendMessageCommand({
       QueueUrl: this.deadLetterQueueUrl,
       MessageBody: transportMessage.raw.Body!,
       MessageAttributes: transportMessage.raw.MessageAttributes
-    }).promise()
+    });
+    await this.sqs.send(command);
+
     await this.deleteMessage(transportMessage)
   }
 
-  async readNextMessage (): Promise<TransportMessage<SQS.Message> | undefined> {
-    const receiveRequest: SQS.ReceiveMessageRequest = {
+  async readNextMessage (): Promise<TransportMessage<SQSMessage> | undefined> {
+    const command = new ReceiveMessageCommand({
       QueueUrl: this.queueUrl,
       WaitTimeSeconds: this.sqsConfiguration.waitTimeSeconds || DEFAULT_WAIT_TIME_SECONDS,
       MaxNumberOfMessages: 1,
       MessageAttributeNames: ['.*'],
       AttributeNames: ['ApproximateReceiveCount']
-    }
+    });
 
-    const result = await this.sqs.receiveMessage(receiveRequest).promise()
+    const result = await this.sqs.send(command);
+
     if (!result.Messages || result.Messages.length === 0) {
       return undefined
     }
@@ -157,7 +200,7 @@ export class SqsTransport implements Transport<SQS.Message> {
       )
       await Promise.allSettled(
         result.Messages
-          .map(async message => this.makeMessageVisible(message))
+          .map(async (message: any) => this.makeMessageVisible(message))
       )
       return undefined
     }
@@ -204,11 +247,11 @@ export class SqsTransport implements Transport<SQS.Message> {
     }
   }
 
-  async deleteMessage (message: TransportMessage<SQS.Message>): Promise<void> {
+  async deleteMessage (message: TransportMessage<SQSMessage>): Promise<void> {
     await this.deleteSqsMessage(message.raw)
   }
 
-  async returnMessage (message: TransportMessage<SQS.Message>): Promise<void> {
+  async returnMessage (message: TransportMessage<SQSMessage>): Promise<void> {
     await this.makeMessageVisible(message.raw)
   }
 
@@ -224,7 +267,7 @@ export class SqsTransport implements Transport<SQS.Message> {
       }
     )
 
-    const serviceQueueAttributes: QueueAttributeMap = {
+    const serviceQueueAttributes: Record<string, string> = {
       VisibilityTimeout: `${this.sqsConfiguration.visibilityTimeout || DEFAULT_VISIBILITY_TIMEOUT}`,
       RedrivePolicy: JSON.stringify({
         maxReceiveCount: this.sqsConfiguration.maxReceiveCount ?? DEFAULT_MAX_RETRY_COUNT,
@@ -233,12 +276,12 @@ export class SqsTransport implements Transport<SQS.Message> {
     }
 
     await this.assertSqsQueue(
-      this.sqsConfiguration.queueName,
+      this.sqsConfiguration.queueName!,
       serviceQueueAttributes
     )
 
     await this.subscribeQueueToMessages()
-    await this.attachPolicyToQueue(this.queueUrl, this.sqsConfiguration.awsAccountId, this.sqsConfiguration.awsRegion)
+    await this.attachPolicyToQueue(this.queueUrl, this.sqsConfiguration.awsAccountId!, this.sqsConfiguration.awsRegion!)
     await this.syncQueueAttributes(this.queueUrl, serviceQueueAttributes)
   }
 
@@ -251,8 +294,8 @@ export class SqsTransport implements Transport<SQS.Message> {
     if (!this.registeredMessages[messageName]) {
       const snsTopicName = this.resolveTopicName(messageName)
       const snsTopicArn = this.resolveTopicArn(
-        this.sqsConfiguration.awsAccountId,
-        this.sqsConfiguration.awsRegion,
+        this.sqsConfiguration.awsAccountId!,
+        this.sqsConfiguration.awsRegion!,
         messageName
       )
       await this.createSnsTopic(snsTopicName)
@@ -265,17 +308,17 @@ export class SqsTransport implements Transport<SQS.Message> {
    */
   private async assertSqsQueue (
     queueName: string,
-    queueAttributes?: QueueAttributeMap
+    queueAttributes?: Record<string, string>
   ): Promise<void> {
     this.logger.info('Asserting sqs queue...', { queueName, queueAttributes })
 
-    const createQueueRequest: SQS.CreateQueueRequest = {
+    const command = new CreateQueueCommand({
       QueueName: queueName,
       Attributes: queueAttributes
-    }
+    });
 
     try {
-      await this.sqs.createQueue(createQueueRequest).promise()
+      await this.sqs.send(command);
     } catch (err) {
       const error = err as { code: string }
       if (error.code === 'QueueAlreadyExists') {
@@ -295,8 +338,8 @@ export class SqsTransport implements Transport<SQS.Message> {
 
     const topicName = this.resolveTopicName(message.$name)
     const topicArn = this.resolveTopicArn(
-      this.sqsConfiguration.awsAccountId,
-      this.sqsConfiguration.awsRegion,
+      this.sqsConfiguration.awsAccountId!,
+      this.sqsConfiguration.awsRegion!,
       topicName
     )
     this.logger.trace('Publishing message to sns', { message, topicArn })
@@ -304,14 +347,16 @@ export class SqsTransport implements Transport<SQS.Message> {
     const attributeMap = toMessageAttributeMap(messageAttributes)
     this.logger.debug('Resolved message attributes', { attributeMap })
 
-    const snsMessage: SNS.PublishInput = {
+    const command = new PublishCommand({
       TopicArn: topicArn,
       Subject: message.$name,
       Message: this.coreDependencies.messageSerializer.serialize(message),
       MessageAttributes: attributeMap
-    }
-    this.logger.debug('Sending message to SNS', { snsMessage })
-    await this.sns.publish(snsMessage).promise()
+    });
+
+    this.logger.debug('Sending message to SNS', { command })
+
+    await this.sns.send(command);
   }
 
   private async subscribeQueueToMessages (): Promise<void> {
@@ -345,64 +390,70 @@ export class SqsTransport implements Transport<SQS.Message> {
       This action is idempotent, so if the topic exists then this will just return. This
       is preferable to checking `sns.listTopics` first as it can't be run in a transaction.
     */
-    const result = await this.sns.createTopic({ Name: topicName }).promise()
+    const command = new CreateTopicCommand({ Name: topicName });
+    const result = await this.sns.send(command);
     return result.TopicArn!
   }
 
   private async subscribeToTopic (queueArn: string, topicArn: string): Promise<void> {
-    const subscribeRequest: SNS.SubscribeInput = {
+    const command = new SubscribeCommand({
       TopicArn: topicArn,
       Protocol: 'sqs',
       Endpoint: queueArn
-    }
+    });
+
     this.logger.info('Subscribing sqs queue to sns topic', { serviceQueueArn: queueArn, topicArn })
-    await this.sns.subscribe(subscribeRequest).promise()
+
+    await this.sns.send(command);
   }
 
-  private async makeMessageVisible (sqsMessage: SQS.Message): Promise<void> {
-    const changeVisibilityRequest: SQS.ChangeMessageVisibilityRequest = {
+  private async makeMessageVisible (sqsMessage: SQSMessage): Promise<void> {
+    const command = new ChangeMessageVisibilityCommand({
       QueueUrl: this.queueUrl,
       ReceiptHandle: sqsMessage.ReceiptHandle!,
       VisibilityTimeout: this.calculateVisibilityTimeout(sqsMessage)
-    }
+    });
 
-    await this.sqs.changeMessageVisibility(changeVisibilityRequest).promise()
+    await this.sqs.send(command);
   }
 
-  private async deleteSqsMessage (sqsMessage: SQS.Message): Promise<void> {
-    const deleteMessageRequest: SQS.DeleteMessageRequest = {
+  private async deleteSqsMessage (sqsMessage: SQSMessage): Promise<void> {
+    const command = new DeleteMessageCommand({
       QueueUrl: this.queueUrl,
       ReceiptHandle: sqsMessage.ReceiptHandle!
-    }
-    this.logger.debug('Deleting message from sqs queue', { deleteMessageRequest })
-    await this.sqs.deleteMessage(deleteMessageRequest).promise()
+    });
+    this.logger.debug('Deleting message from sqs queue', { command })
+    await this.sqs.send(command);
   }
 
   private async attachPolicyToQueue (queueUrl: string, awsAccountId: string, awsRegion: string): Promise<void> {
     const policy = this.sqsConfiguration.queuePolicy || generatePolicy(awsAccountId, awsRegion)
-    const setQueuePolicyRequest: SQS.SetQueueAttributesRequest = {
+    const command = new SetQueueAttributesCommand({
       QueueUrl: queueUrl,
       Attributes: {
         Policy: policy
       }
-    }
+    })
 
     this.logger.info('Attaching IAM policy to queue', { policy, serviceQueueUrl: queueUrl })
-    await this.sqs.setQueueAttributes(setQueuePolicyRequest).promise()
+    await this.sqs.send(command);
   }
 
-  private async syncQueueAttributes (queueUrl: string, attributes: QueueAttributeMap): Promise<void> {
+  private async syncQueueAttributes (queueUrl: string, attributes?: Record<string, string>): Promise<void> {
     // Check equality first to avoid potential API rate limit
-    const existingAttributes = await this.sqs.getQueueAttributes({ QueueUrl: queueUrl }).promise()
-    if (existingAttributes.Attributes !== attributes) {
-      await this.sqs.setQueueAttributes({
+    const existing = await this.sqs.send(new GetQueueAttributesCommand({
+      QueueUrl: queueUrl
+    }));
+
+    if (existing.Attributes !== attributes) {
+      await this.sqs.send(new SetQueueAttributesCommand({
         QueueUrl: queueUrl,
         Attributes: attributes
-      }).promise()
+      }));
     }
   }
 
-  private calculateVisibilityTimeout (sqsMessage: SQS.Message): Seconds {
+  private calculateVisibilityTimeout (sqsMessage: SQSMessage): Seconds {
     const currentReceiveCount = parseInt(
       sqsMessage.Attributes && sqsMessage.Attributes.ApproximateReceiveCount || '0',
       10
@@ -415,8 +466,8 @@ export class SqsTransport implements Transport<SQS.Message> {
   }
 }
 
-export function toMessageAttributeMap (messageOptions: MessageAttributes): SNS.MessageAttributeMap {
-  const map: SNS.MessageAttributeMap = {}
+export function toMessageAttributeMap (messageOptions: MessageAttributes): SnsMessageAttributeMap {
+  const map: SnsMessageAttributeMap = {}
 
   const toAttributeValue = (value: string | number | boolean) => {
     const attribute: MessageAttributeValue = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,781 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/ie11-detection@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz#640ae66b4ec3395cee6a8e94ebcd9f80c24cd688"
+  integrity sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz#05f160138ab893f1c6ba5be57cfd108f05827766"
+  integrity sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^3.0.0"
+    "@aws-crypto/sha256-js" "^3.0.0"
+    "@aws-crypto/supports-web-crypto" "^3.0.0"
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@3.0.0", "@aws-crypto/sha256-js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz#f06b84d550d25521e60d2a0e2a90139341e007c2"
+  integrity sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz#5d1bf825afa8072af2717c3e455f35cda0103ec2"
+  integrity sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-3.0.0.tgz#1c7ca90c29293f0883468ad48117937f0fe5bfb0"
+  integrity sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.289.0.tgz#94278f94c66ea48b0a2da70256abc036c85de6a9"
+  integrity sha512-Xakz8EeTl0Q3KaWRdCaRQrrYxBAkQGj6eeT+DVmMLMz4gzTcSHwvfR5tVBIPHk4+IjboJJKM5l1xAZ90AGFPAQ==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sns@^3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sns/-/client-sns-3.289.0.tgz#085efe020e922d6e083f5ebf5f3ca8d56bd44f04"
+  integrity sha512-LhRKLBNfh/2KImlfB8V8lSaUnzwW2oMdYlp2xiN/Xlb2ya1fohTGsBoJ0AxVgwop9nfeZZhdFinsjIMaMeN+OA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.289.0"
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/credential-provider-node" "3.289.0"
+    "@aws-sdk/fetch-http-handler" "3.289.0"
+    "@aws-sdk/hash-node" "3.289.0"
+    "@aws-sdk/invalid-dependency" "3.289.0"
+    "@aws-sdk/middleware-content-length" "3.289.0"
+    "@aws-sdk/middleware-endpoint" "3.289.0"
+    "@aws-sdk/middleware-host-header" "3.289.0"
+    "@aws-sdk/middleware-logger" "3.289.0"
+    "@aws-sdk/middleware-recursion-detection" "3.289.0"
+    "@aws-sdk/middleware-retry" "3.289.0"
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/middleware-signing" "3.289.0"
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/middleware-user-agent" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/node-http-handler" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/smithy-client" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.289.0"
+    "@aws-sdk/util-defaults-mode-node" "3.289.0"
+    "@aws-sdk/util-endpoints" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    "@aws-sdk/util-user-agent-browser" "3.289.0"
+    "@aws-sdk/util-user-agent-node" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    fast-xml-parser "4.1.2"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sqs@^3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sqs/-/client-sqs-3.289.0.tgz#78c75bb78fcf264386a95aac1486f25c308ed365"
+  integrity sha512-I6OpCtatFXrK2l06/RpAsxIVBpmAec4mbyagCNAgWHCnq9WIf8azS8BZAEsviWMeTWA5jdfyOwu/qpwNtUcLQA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.289.0"
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/credential-provider-node" "3.289.0"
+    "@aws-sdk/fetch-http-handler" "3.289.0"
+    "@aws-sdk/hash-node" "3.289.0"
+    "@aws-sdk/invalid-dependency" "3.289.0"
+    "@aws-sdk/md5-js" "3.289.0"
+    "@aws-sdk/middleware-content-length" "3.289.0"
+    "@aws-sdk/middleware-endpoint" "3.289.0"
+    "@aws-sdk/middleware-host-header" "3.289.0"
+    "@aws-sdk/middleware-logger" "3.289.0"
+    "@aws-sdk/middleware-recursion-detection" "3.289.0"
+    "@aws-sdk/middleware-retry" "3.289.0"
+    "@aws-sdk/middleware-sdk-sqs" "3.289.0"
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/middleware-signing" "3.289.0"
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/middleware-user-agent" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/node-http-handler" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/smithy-client" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.289.0"
+    "@aws-sdk/util-defaults-mode-node" "3.289.0"
+    "@aws-sdk/util-endpoints" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    "@aws-sdk/util-user-agent-browser" "3.289.0"
+    "@aws-sdk/util-user-agent-node" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    fast-xml-parser "4.1.2"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso-oidc@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.289.0.tgz#dd1945682685b05c7b8700593f95c8cb9788fe08"
+  integrity sha512-+09EK4aWdNjF+5+nK6Dmlwx3es8NTkyABTOj9H4eKB90rXQVX8PjoaFhK/b+NcNKDxgb1E6k6evZEpAb8dYQHg==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/fetch-http-handler" "3.289.0"
+    "@aws-sdk/hash-node" "3.289.0"
+    "@aws-sdk/invalid-dependency" "3.289.0"
+    "@aws-sdk/middleware-content-length" "3.289.0"
+    "@aws-sdk/middleware-endpoint" "3.289.0"
+    "@aws-sdk/middleware-host-header" "3.289.0"
+    "@aws-sdk/middleware-logger" "3.289.0"
+    "@aws-sdk/middleware-recursion-detection" "3.289.0"
+    "@aws-sdk/middleware-retry" "3.289.0"
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/middleware-user-agent" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/node-http-handler" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/smithy-client" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.289.0"
+    "@aws-sdk/util-defaults-mode-node" "3.289.0"
+    "@aws-sdk/util-endpoints" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    "@aws-sdk/util-user-agent-browser" "3.289.0"
+    "@aws-sdk/util-user-agent-node" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.289.0.tgz#a77f13b1de5923c0a3048e0e1548ceef09d49cab"
+  integrity sha512-GIpxPaEwqXC+P8wH+G4mIDnxYFJ+2SyYTrnoxb4OUH+gAkU6tybgvsv0fy+jsVD6GAWPdfU1AYk2ZjofdFiHeA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/fetch-http-handler" "3.289.0"
+    "@aws-sdk/hash-node" "3.289.0"
+    "@aws-sdk/invalid-dependency" "3.289.0"
+    "@aws-sdk/middleware-content-length" "3.289.0"
+    "@aws-sdk/middleware-endpoint" "3.289.0"
+    "@aws-sdk/middleware-host-header" "3.289.0"
+    "@aws-sdk/middleware-logger" "3.289.0"
+    "@aws-sdk/middleware-recursion-detection" "3.289.0"
+    "@aws-sdk/middleware-retry" "3.289.0"
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/middleware-user-agent" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/node-http-handler" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/smithy-client" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.289.0"
+    "@aws-sdk/util-defaults-mode-node" "3.289.0"
+    "@aws-sdk/util-endpoints" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    "@aws-sdk/util-user-agent-browser" "3.289.0"
+    "@aws-sdk/util-user-agent-node" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.289.0.tgz#4da58cfd24f6a974d7e07aae57753bf084637a51"
+  integrity sha512-n+8zDCzk0NvCIXX3MGS8RV/+/MkJso0jkqkPOgPcS8Kf7Zbjlx8FyeGQ5LS7HjhCDk+jExH/s9h1kd3sL1pHQA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/credential-provider-node" "3.289.0"
+    "@aws-sdk/fetch-http-handler" "3.289.0"
+    "@aws-sdk/hash-node" "3.289.0"
+    "@aws-sdk/invalid-dependency" "3.289.0"
+    "@aws-sdk/middleware-content-length" "3.289.0"
+    "@aws-sdk/middleware-endpoint" "3.289.0"
+    "@aws-sdk/middleware-host-header" "3.289.0"
+    "@aws-sdk/middleware-logger" "3.289.0"
+    "@aws-sdk/middleware-recursion-detection" "3.289.0"
+    "@aws-sdk/middleware-retry" "3.289.0"
+    "@aws-sdk/middleware-sdk-sts" "3.289.0"
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/middleware-signing" "3.289.0"
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/middleware-user-agent" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/node-http-handler" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/smithy-client" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    "@aws-sdk/util-body-length-browser" "3.188.0"
+    "@aws-sdk/util-body-length-node" "3.208.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.289.0"
+    "@aws-sdk/util-defaults-mode-node" "3.289.0"
+    "@aws-sdk/util-endpoints" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    "@aws-sdk/util-user-agent-browser" "3.289.0"
+    "@aws-sdk/util-user-agent-node" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    fast-xml-parser "4.1.2"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.289.0.tgz#a6f148afe9ba57fff5e1168c128adbda15378772"
+  integrity sha512-QYrBJeFJwx9wL73xMJgSTS6zY5SQh0tbZXpVlSZcNDuOufsu5zdcZZCOp0I20yGf8zxKX59u7O73OUlppkk+Wg==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.289.0.tgz#4cbf2a0cf4b8d9c9d4438782c480b7a65918a3c1"
+  integrity sha512-h4yNEW2ZJATKVxL0Bvz/WWXUmBr+AhsTyjUNge734306lXNG5/FM7zYp2v6dSQWt02WwBXyfkP3lr+A0n4rHyA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.289.0.tgz#8cf6a5c612c8193105d5891ff5afde1fb98cdca2"
+  integrity sha512-SIl+iLQpDR6HA9CKTebui7NLop5GxnCkufbM3tbSqrQcPcEfYLOwXpu5gpKO2unQzRykCoyRVia1lr7Pc9Hgdg==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.289.0.tgz#99d1a5f3a0b92ff45af450c7240e47e5988c6178"
+  integrity sha512-kvNUn3v4FTRRiqCOXl46v51VTGOM76j5Szcrhkk9qeFW6zt4iFodp6tQ4ynDtDxYxOvjuEfm3ii1YN5nkI1uKA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.289.0"
+    "@aws-sdk/credential-provider-imds" "3.289.0"
+    "@aws-sdk/credential-provider-process" "3.289.0"
+    "@aws-sdk/credential-provider-sso" "3.289.0"
+    "@aws-sdk/credential-provider-web-identity" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.289.0.tgz#bf55caf0ce120f784614c5870f4308ba257ff38c"
+  integrity sha512-05CYPGnk5cDiOQDIaXNVibNOwQdI34MDiL17YkSfPv779A+uq4vqg/aBfL41BDJjr1gSGgyvVhlcUdBKnlp93Q==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.289.0"
+    "@aws-sdk/credential-provider-imds" "3.289.0"
+    "@aws-sdk/credential-provider-ini" "3.289.0"
+    "@aws-sdk/credential-provider-process" "3.289.0"
+    "@aws-sdk/credential-provider-sso" "3.289.0"
+    "@aws-sdk/credential-provider-web-identity" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.289.0.tgz#ef91f39541a607dde73c3df81715d8f2b176991f"
+  integrity sha512-t39CJHj1/f2DcRbEUSJ1ixwDsgaElDpJPynn59MOdNnrSh5bYuYmkrum/GYXYSsk+HoSK21JvwgvjnrkA9WZKQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.289.0.tgz#64bf7e3a2f017f5988174dd6193da6e8f187b1b6"
+  integrity sha512-8+DjOqj5JCpVdT4EJtdfis6OioAdiDKM1mvgDTG8R43MSThc+RGfzqaDJQdM+8+hzkYhxYfyI9XB0H+X3rDNsA==
+  dependencies:
+    "@aws-sdk/client-sso" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/token-providers" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.289.0.tgz#14d9fa1e5f237abafc04533e34b9750565874b9a"
+  integrity sha512-jZ9hQvr0I7Z2DekDtZytViYn7zNNJG06N0CinAJzzvreAQ1I61rU7mhaWc05jhBSdeA3f82XoDAgxqY4xIh9pQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.289.0.tgz#f09712c82d865423728539e26cbee20b91021e3c"
+  integrity sha512-tksh2GnDV1JaI+NO9x+pgyB3VNwjnUdtoMcFGmTDm1TrcPNj0FLX2hLiunlVG7fFMfGLXC2aco0sUra5/5US9Q==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/querystring-builder" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-base64" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.289.0.tgz#f588be8b67762823d54e7814d174c3ee76127c62"
+  integrity sha512-fL7Pt4LU+tluHn0+BSIFVD2ZVJ5fuXvd1hQt4aTYrgkna1RR5v55Hdy2rNrp/syrkyE+Wv92S3hgZ7ZTBeXFZA==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.289.0.tgz#29abc018752f92485c2aa07c6e4d48f676657726"
+  integrity sha512-VpXadvpqXFUA8gBH6TAAJzsKfEQ4IvsiD7d9b2B+jw1YtaPFTqEEuDjN6ngpad8PCPCNWl8CI6oBCdMOK+L48A==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz#06e557adc284fac2f26071c2944ae01f61b95854"
+  integrity sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/md5-js@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/md5-js/-/md5-js-3.289.0.tgz#22ba72a1574af103037204b33f32f8a4229114d1"
+  integrity sha512-8GU6V0aJJ0kcWD9UncJJZ5z3H4Dj62dbgpEW590XZwGC6MJ8/OtIlearAdGmNNSsKkAyEY0xiWiasDWstQLmuQ==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.289.0.tgz#86a8f77faa6dc228a030bdcc0fd35947be920f8a"
+  integrity sha512-D7vGeuaAzKiq0aFPwme1Xy4x69Jn4v0YJ3Xa4J+keNep0yZ9LfU5KSngqsxeTefCqS+2tdaArkBN2VdexmPagw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-endpoint@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.289.0.tgz#99b6c2e064e693c62873dad62c78c9bf551128d6"
+  integrity sha512-nxaQFOG1IurwCHWP22RxgTFZdILsdBg6wbg4GeFpNBtE3bi0zIUYKrUhpdRr/pZyGAboD1oD9iQtxuGb/M6f+w==
+  dependencies:
+    "@aws-sdk/middleware-serde" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/signature-v4" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/url-parser" "3.289.0"
+    "@aws-sdk/util-config-provider" "3.208.0"
+    "@aws-sdk/util-middleware" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.289.0.tgz#0fe22ed1930d600844666ea80ef2f6717c52bd57"
+  integrity sha512-yFBOKvKBnITO08JCx+65vXPe9Uo4gZuth/ka9v5swa4wtV8AP+kkOwFrNxSi2iAFLJ4Mg21vGQceeL0bErF6KQ==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.289.0.tgz#fd6de1ebcef0ff3fffe4f407162542bdfb9d7065"
+  integrity sha512-c5W7AlOdoyTXRoNl2yOVkhbTjp8tX0z65GDb3+/1yYcv+GRtz67WMZscWMQJwEfdCLdDE2GtBe+t2xyFGnmJvA==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.289.0.tgz#8d185c2bb9f80215b51f3c1700914f04c4c84fe9"
+  integrity sha512-r2NrfnTG0UZRXeFjoyapAake7b1rUo6SC52/UV4Pdm8cHoYMmljnaGLjiAfzt6vWv6cSVCJq1r28Ne4slAoMAg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.289.0.tgz#68534fbd94c40feb11a22b134285db9089b47336"
+  integrity sha512-Su+iGv5mrFjVCXJmjohX00o3HzkwnhY0TDhIltgolB6ZfOqy3Dfopjj21OWtqY9VYCUiLGC4KRfeb2feyrz5BA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/service-error-classification" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-middleware" "3.289.0"
+    "@aws-sdk/util-retry" "3.289.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-sqs@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.289.0.tgz#f3f19a591cdbfaa1aa37dec50821fd35b1863e5a"
+  integrity sha512-BDPbibQEBmCOtdw1tpt4MJE0skqqgA3/oxuDxG9UlOlkTR3pFKG1r6ksLDQM5eFzlWRoff97q6ax3If7u1byGw==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-sdk-sts@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.289.0.tgz#aa5b8a075aea6c1af5bbb292a26d085985373ad6"
+  integrity sha512-9WzUVPEqJcvggGCk9JHXnwhj7fjuMXE/JM3gx7eMSStJCcK+3BARZ1RZnggUN4vN9iTSzdA+r0OpC1XnUGKB2g==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/signature-v4" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.289.0.tgz#095ed906dd0c3ca9afe0bd97aeada2f64ebd30e7"
+  integrity sha512-pygC+LsEBVAxOzfoxA9jgvqfO1PLivh8s2Yr/aNQOwx49fmTHMvPwRYUGDV38Du6bRYcKI6nxYqkbJFkQkRESQ==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.289.0.tgz#e262bea9bc1e61d52d7fbcf81c329a07fd60e783"
+  integrity sha512-9SLATNvibxg4hpr4ldU18LwB6AVzovONWeJLt49FKISz7ZwGF6WVJYUMWeScj4+Z51Gozi7+pUIaFn7i6N3UbA==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/signature-v4" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-middleware" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.289.0.tgz#e08558014f45622783e76c2d7cf85191434101b3"
+  integrity sha512-3rWx+UkV//dv/cLIrXmzIa+FZcn6n76JevGHYCTReiRpcvv+xECxgXH2crMYtzbu05WdxGYD6P0IP5tMwH0yXA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.289.0.tgz#5650f57906b0fff32f739e47425c603f987aef11"
+  integrity sha512-XPhB9mgko66BouyxA+7z7SjUaNHyr58Xe/OB8GII5R/JiR3A/lpc8+jm9gEEpjEI/HpF8jLFDnTMbgabVAHOeA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.289.0.tgz#815a760a9ed6c4e5b5cd7e8bf62fa7d7dd2fe6fb"
+  integrity sha512-rR41c3Y7MYEP8TG9X1whHyrXEXOZzi4blSDqeJflwtNt3r3HvErGZiNBdVv368ycPPuu1YRSqTkgOYNCv02vlw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.289.0.tgz#b1a8fc4bce4c257e8a15d7ecdebc25bca2afafb2"
+  integrity sha512-zKknSaOY2GNmqH/eoZndmQWoEKhYPV0qRZtAMxuS3DVI5fipBipNzbVBaXrHRjxARx7/VLWnvNArchRoHfOlmw==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.289.0"
+    "@aws-sdk/protocol-http" "3.289.0"
+    "@aws-sdk/querystring-builder" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.289.0.tgz#ff95153868c94b8def757a7a8d9eeb8603a1c874"
+  integrity sha512-Raf4lTWPTmEGFV7Lkbfet2n/4Ybz5vQiiU45l56kgIQA88mLUuE4dshgNsM0Zb2rflsTaiN1JR2+RS/8lNtI8A==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.289.0.tgz#ebaa84ebd9ac1129459082c0990cd37d5355f2b1"
+  integrity sha512-/2jOQ3MJZx1xk6BHEOW47ItGo1tgA9cP9a2saYneon05VIV6OuYefO5pG2G0nPnImTbff++N7aioXe5XKrnorw==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.289.0.tgz#75ddef075862746cbf6d92f71bb8715cedeef61f"
+  integrity sha512-llJCS8mAJfBYBjkKeriRmBuDr2jIozrMWhJOkz95SQGFsx1sKBPQMMOV6zunwhQux8bjtjf5wYiR1TM2jNUKqQ==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.289.0.tgz#0aa11faa53203a1cfc30d3e0c48d70284f378ec2"
+  integrity sha512-84zXKXIYtnTCrez/gGZIGuqfUJezzaOMm7BQwnOnq/sN21ou63jF3Q+tIMhLO/EvDcvmxEOlUXN1kfMQcjEjSw==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.289.0.tgz#25c513c099126414ed2e8489290b3a4f0e0f2c4b"
+  integrity sha512-+d1Vlb45Bs2gbTmXpRCGQrX4AQDETjA5sx1zLvq1NZGSnTX6LdroYPtXu3dRWJwDHHQpCMN/XfFN8jTw0IzBOg==
+
+"@aws-sdk/shared-ini-file-loader@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.289.0.tgz#ac3eb207374bef778638c75cc65233d9d9a64dae"
+  integrity sha512-XG9Pfn3itf3Z0p6nY6UuMVMhzZb+oX7L28oyby8REl8BAwfPkcziLxXlZsBHf6KcgYDG1R6z945hvIwZhJbjvA==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.289.0.tgz#be2f2533a52e13733e7ae88fbf083ec6357cc47a"
+  integrity sha512-IQyYHx3zp7PHxFA17YDb6WVx8ejXDxrsnKspFXgZQyoZOPfReqWQs32dcJYXff/IdSzxjwOpwBFbmIt2vbdKnQ==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    "@aws-sdk/types" "3.289.0"
+    "@aws-sdk/util-hex-encoding" "3.201.0"
+    "@aws-sdk/util-middleware" "3.289.0"
+    "@aws-sdk/util-uri-escape" "3.201.0"
+    "@aws-sdk/util-utf8" "3.254.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.289.0.tgz#d9ff0e50cb311662c8e4029791cfef2220d00b0a"
+  integrity sha512-miPMdnv4Ivv8RN65LJ9dxzkQNHn9Tp9wzZJXwBcPqGdXyRlkWSuIOIIhhAqQoV9R9ByeshnCWBpwqlITIjNPVw==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/token-providers@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.289.0.tgz#ecfaa3462966c77508a64b3498319e2bfcbc4476"
+  integrity sha512-fzvGIfJNoLR5g24ok8cRwc9AMLXoEOyfi+eHocAF6eyfe0NWlQtpsmLe7XXx5I9yZ51lclzV49rEz9ynp243RA==
+  dependencies:
+    "@aws-sdk/client-sso-oidc" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/shared-ini-file-loader" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.289.0", "@aws-sdk/types@^3.222.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.289.0.tgz#c1042bcefa21e90e754ba665094599fa8a7f35f8"
+  integrity sha512-wwUC+VwoNlEkgDzK/aJG3+zeMcYRcYFQV4mbZaicYdp3v8hmkUkJUhyxuZYl/FmY46WG+DYv+/Y3NilgfsE+Wg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/url-parser@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.289.0.tgz#d2320e6174cc883abe2f03a27dcf918c40e0c5f0"
+  integrity sha512-rbtW3O6UBX+eWR/+UiCDNFUVwN8hp82JPy+NGv3NeOvRjBsxkKmcH4UJTHDIeT+suqTDNEdV5nz438u3dHdHrQ==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-arn-parser@^3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz#56b6ae4699c3140bb27dcede5146876fef04e823"
+  integrity sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz#36b430e5396251f761590f7c2f0c5c12193f353c"
+  integrity sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.188.0":
+  version "3.188.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz#e1d949318c10a621b38575a9ef01e39f9857ddb0"
+  integrity sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz#baabd1fa1206ff2bd4ce3785122d86eb3258dd20"
+  integrity sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz#285e86f6dc9030148a4147d65239e75cb254a1b0"
+  integrity sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.201.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.208.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz#c485fd83fbac051337e5f6be60ea3f9fa61c0139"
+  integrity sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.289.0.tgz#8f1f5e6926e18ba6f8a6c22d237e82649aca650c"
+  integrity sha512-sYrDwjX3s54cvGq69PJpP2vDpJ5BJXhg2KEHbK92Qr2AUqMUgidwZCw4oBaIqKDXcPIrjmhod31s3tTfYmtTMQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.289.0.tgz#1badaf2383f5de055e9a23fce5151b9eb31f94a2"
+  integrity sha512-PsP40+9peN7kpEmQ2GhEAGwUwD9F/R/BI/1kzjW0nbBsMrTnkUnlZlaitwpBX/OWNV/YZTdVAOvD50j/ACyXlg==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.289.0"
+    "@aws-sdk/credential-provider-imds" "3.289.0"
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/property-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-endpoints@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.289.0.tgz#556add88acaa0e77c2c8c356c876ea215ac60211"
+  integrity sha512-PmsgqL9jdNTz3p0eW83nZZGcngAdoIWidXCc32G5tIIYvJutdgkiObAaydtXaMgk5CRvjenngFf6Zg9JyVHOLQ==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz#21d7ec319240ee68c33d938e71cb79830bea315d"
+  integrity sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.208.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz#0f598fc238a1256e4bcb64d01459f03a922dd4c3"
+  integrity sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.289.0.tgz#b8f2c9a08c23ed064054a19640d5a1c1911cefce"
+  integrity sha512-hw3WHQU9Wk7a1H3x+JhwMA4ECCleeuNlob3fXSYJmXgvZyuWfpMYZi4iSkqoWGFAXYpAtZZLIu45iIcd7F296g==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-retry@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-retry/-/util-retry-3.289.0.tgz#fb800797cf9908a8346311bc00dbb5c032e702e4"
+  integrity sha512-noFn++ZKH11ExTBqUU/b9wsOjqxYlDnN/8xq+9oCsyBnEZztVgM/AM3WP5qBPRskk1WzDprID5fb5V87113Uug==
+  dependencies:
+    "@aws-sdk/service-error-classification" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.201.0":
+  version "3.201.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz#5e708d4cde001a4558ee616f889ceacfadd2ab03"
+  integrity sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.289.0.tgz#90dfb622d3f707d8cde9fb25c4bd548930821657"
+  integrity sha512-BDXYgNzzz2iNPTkl9MQf7pT4G80V6O6ICwJyH93a5EEdljl7oPrt8i4MS5S0BDAWx58LqjWtVw98GOZfy5BYhw==
+  dependencies:
+    "@aws-sdk/types" "3.289.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.289.0":
+  version "3.289.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.289.0.tgz#048f86cf5dd4822f703aaac5f6e5adbf6cf6175f"
+  integrity sha512-f32g9KS7pwO6FQ9N1CtqQPIS6jhvwv/y0+NHNoo9zLTBH0jol3+C2ELIE3N1wB6xvwhsdPqR3WuOiNiCiv8YAQ==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.289.0"
+    "@aws-sdk/types" "3.289.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz#3275a6f5eb334f96ca76635b961d3c50259fd9ff"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8@3.254.0":
+  version "3.254.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz#909af9c6549833a9a9bf77004b7484bfc96b2c35"
+  integrity sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.208.0"
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
@@ -1911,21 +2686,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.834.0:
-  version "2.1003.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1003.0.tgz#f4ca218f466c524a90370b5604a3ad4cda4c0e08"
-  integrity sha512-UEZveI1m7+/YsomU2tVxLMmlo5g3sr3ue+QMJ2UwbrvHZ+O9hr9vVia1lD+L8fYTQenOff95NFc02h3pDE3iDA==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.15.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2041,11 +2801,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2084,6 +2839,11 @@ bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2153,15 +2913,6 @@ buffer-writer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
-
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
@@ -3027,11 +3778,6 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
-
 exec-sh@^0.3.2:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
@@ -3183,6 +3929,13 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-xml-parser@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
+  integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
+  dependencies:
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.11.1"
@@ -3681,16 +4434,6 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
@@ -4069,7 +4812,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -4617,11 +5360,6 @@ jest@^27.0.5:
     "@jest/core" "^27.2.4"
     import-local "^3.0.2"
     jest-cli "^27.2.4"
-
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -6051,11 +6789,6 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -6087,11 +6820,6 @@ query-string@^6.13.8:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -6439,16 +7167,6 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
-
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^5.0.1:
   version "5.0.1"
@@ -6882,6 +7600,11 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 strong-log-transformer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -7113,6 +7836,11 @@ tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tslint@^5.12.1:
   version "5.20.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
@@ -7340,14 +8068,6 @@ url-parse@~1.5.1:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -7364,11 +8084,6 @@ util-promisify@^2.1.0:
   integrity sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
-
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -7589,19 +8304,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This PR proposes the following:

- Update `bus-sqs` to use AWS SDK v3
- Allow passing the full `queueArn` instead of `awsAccountId` and `awsRegion`
- Allow passing the full `deadLetterQueueArn`

This update has the advantage of producing smaller bundles, as v3 is tree-shakable, as well as automatic discovery of AWS environment and credentials data (a built-in with v3). This PR also makes this package much smaller as the latest v2 aws-sdk weighs in at a massive 77mb https://packagephobia.com/result?p=aws-sdk.