### PR TITLE
FIX #200: Support Mongodb Persistence for WF

### DIFF
--- a/packages/bus-mongodb/README.md
+++ b/packages/bus-mongodb/README.md
@@ -1,4 +1,4 @@
-# @node-ts/bus-postgres
+# @node-ts/bus-mongodb
 
 A Mongodb based persistence for workflow storage in [@node-ts/bus](https://bus.node-ts.com)
 
@@ -14,11 +14,11 @@ Install all packages and their dependencies
 npm install @node-ts/bus-mongodb
 ```
 
-Configure a new Postgres persistence and register it with `Bus`:
+Configure a new Mongodb persistence and register it with `Bus`:
 
 ```typescript
 import { Bus } from '@node-ts/bus-core'
-import { MongodbPersistence, MongodbConfiguration } from '@node-ts/bus-postgres'
+import { MongodbPersistence, MongodbConfiguration } from '@node-ts/bus-mongodb'
 
 const configuration: MongodbConfiguration = {
   connection: 'mongodb://localhost:27017',

--- a/packages/bus-mongodb/README.md
+++ b/packages/bus-mongodb/README.md
@@ -1,0 +1,52 @@
+# @node-ts/bus-postgres
+
+A Mongodb based persistence for workflow storage in [@node-ts/bus](https://bus.node-ts.com)
+
+🔥 View our docs at [https://bus.node-ts.com](https://bus.node-ts.com) 🔥
+
+🤔 Have a question? [Join our Discord](https://discord.gg/Gg7v4xt82X) 🤔
+
+## Installation
+
+Install all packages and their dependencies
+
+```bash
+npm install @node-ts/bus-mongodb
+```
+
+Configure a new Postgres persistence and register it with `Bus`:
+
+```typescript
+import { Bus } from '@node-ts/bus-core'
+import { MongodbPersistence, MongodbConfiguration } from '@node-ts/bus-postgres'
+
+const configuration: MongodbConfiguration = {
+  connection: 'mongodb://localhost:27017',
+  databaseName: 'workflows'
+}
+const mongodbPersistence = new MongodbPersistence(configuration)
+
+// Configure bus to use mongodb as a persistence
+const run = async () => {
+  await Bus
+    .configure()
+    .withPersistence(mongodbPersistence)
+    .initialize()
+}
+run.then(() => void)
+```
+
+## Configuration Options
+
+The Mongodb persistence has the following configuration:
+
+*  **connection** *(required)* The mongodb connection string to use. This can be a single server, a replica set, or a mongodb+srv connection.
+*  **schemaName** *(required)* The database name to create workflow collections inside. 
+
+## Development
+
+Local development can be done with the aid of docker to run the required infrastructure. To do so, run:
+
+```bash
+docker run --name bus-mongodb -p 27017:27017 -d mongo
+```

--- a/packages/bus-mongodb/package.json
+++ b/packages/bus-mongodb/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@node-ts/bus-mongodb",
+  "description": "A Mongodb persistence adapter for workflow storage in @node-ts/bus-workflow.",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "repository": "github:node-ts/bus.git",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc --project tsconfig.json --declaration",
+    "build:watch": "yarn run build --incremental --watch --preserveWatchOutput",
+    "lint": "tslint --project tsconfig.json 'src/**/*.ts'",
+    "lint:fix": "yarn lint --fix"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@node-ts/bus-messages": "^1.0.4",
+    "lodash": "^4.17.21",
+    "mongodb": "^5.3.0",
+    "tslib": "^1.9.3",
+    "uuid": "^3.3.2"
+  },
+  "devDependencies": {
+    "@node-ts/bus-core": "^1.0.15",
+    "@node-ts/code-standards": "^0.0.10",
+    "@types/amqplib": "^0.5.11",
+    "@types/lodash": "^4.14.194",
+    "@types/uuid": "^3.4.4",
+    "reflect-metadata": "^0.1.13",
+    "typemoq": "^2.1.0",
+    "typescript": "^4.3.5"
+  },
+  "peerDependencies": {
+    "@node-ts/bus-core": "^1.0.0-alpha.0"
+  },
+  "keywords": [
+    "esb",
+    "mongodb",
+    "typescript",
+    "enterprise integration patterns",
+    "bus",
+    "messaging",
+    "microservices",
+    "distributed systems",
+    "framework",
+    "enterprise framework",
+    "CQRS",
+    "ES",
+    "NServiceBus",
+    "Mule ESB"
+  ],
+  "gitHead": "265ea7e16c614971d4b01c3642682d6c93feb52f"
+}

--- a/packages/bus-mongodb/src/error/index.ts
+++ b/packages/bus-mongodb/src/error/index.ts
@@ -1,0 +1,1 @@
+export * from './workflow-state-not-found'

--- a/packages/bus-mongodb/src/error/workflow-state-not-found.ts
+++ b/packages/bus-mongodb/src/error/workflow-state-not-found.ts
@@ -1,0 +1,9 @@
+export class WorkflowStateNotFound extends Error {
+  constructor (
+    readonly workflowId: string,
+    readonly tableName: string,
+    readonly version: number
+  ) {
+    super(`Could not find workflow state`)
+  }
+}

--- a/packages/bus-mongodb/src/index.ts
+++ b/packages/bus-mongodb/src/index.ts
@@ -1,0 +1,2 @@
+export * from './mongodb-configuration'
+export * from './mongodb-persistence'

--- a/packages/bus-mongodb/src/mongodb-configuration.ts
+++ b/packages/bus-mongodb/src/mongodb-configuration.ts
@@ -1,0 +1,14 @@
+/**
+ * Provides configuration for creating and configuring a Mongodb persistence provider.
+ */
+export interface MongodbConfiguration {
+  /**
+   * The mongodb connection string to use. This can be a single server, a replica set, or a mongodb+srv connection.
+   */
+  connection: string;
+
+  /**
+   * The database name to create workflow collections inside. 
+   */
+  databaseName: string;
+}

--- a/packages/bus-mongodb/src/mongodb-persistence.integration.ts
+++ b/packages/bus-mongodb/src/mongodb-persistence.integration.ts
@@ -10,7 +10,6 @@ import { MongodbPersistence } from "./mongodb-persistence";
 import { MongodbConfiguration } from "./mongodb-configuration";
 import { Mock } from "typemoq";
 import { TestWorkflowState, TestCommand, TestWorkflow } from "../test";
-import { Pool } from "pg";
 import * as uuid from "uuid";
 import { Collection, Db, MongoClient } from "mongodb";
 import { WorkflowStateNotFound } from "./error";

--- a/packages/bus-mongodb/src/mongodb-persistence.integration.ts
+++ b/packages/bus-mongodb/src/mongodb-persistence.integration.ts
@@ -1,0 +1,160 @@
+import {
+  Bus,
+  WorkflowStatus,
+  MessageWorkflowMapping,
+  Logger,
+  BusInstance,
+} from "@node-ts/bus-core";
+import { MessageAttributes } from "@node-ts/bus-messages";
+import { MongodbPersistence } from "./mongodb-persistence";
+import { MongodbConfiguration } from "./mongodb-configuration";
+import { Mock } from "typemoq";
+import { TestWorkflowState, TestCommand, TestWorkflow } from "../test";
+import { Pool } from "pg";
+import * as uuid from "uuid";
+import { Collection, Db, MongoClient } from "mongodb";
+import { WorkflowStateNotFound } from "./error";
+
+const configuration: MongodbConfiguration = {
+  connection: "mongodb://localhost:27017/workflows",
+  databaseName: "workflows",
+};
+
+describe("MongodbPersistence", () => {
+  let sut: MongodbPersistence;
+  let client: MongoClient;
+  let database: Db;
+  let collection: Collection;
+  let bus: BusInstance;
+
+  beforeAll(async () => {
+    client = new MongoClient(configuration.connection);
+    client = await client.connect();
+    database = client.db(configuration.databaseName) as Db;
+    collection = database.collection("testworkflowstate") as Collection;
+    sut = new MongodbPersistence(configuration);
+    bus = await Bus.configure()
+      .withLogger(() => Mock.ofType<Logger>().object)
+      .withPersistence(sut)
+      .withWorkflow(TestWorkflow)
+      .initialize();
+
+    await bus.start();
+  });
+
+  afterAll(async () => {
+    await client.db(configuration.databaseName).dropDatabase();
+    await bus.dispose();
+  });
+
+  describe("when initializing the persistence", () => {
+    it("should create a workflow table", async () => {
+      const count = await collection.countDocuments();
+      expect(count).toEqual(0);
+    });
+  });
+
+  describe("when saving new workflow state", () => {
+    const workflowState = new TestWorkflowState();
+    workflowState.$workflowId = uuid.v4();
+    workflowState.$status = WorkflowStatus.Running;
+    workflowState.$version = 0;
+    workflowState.eventValue = "abc";
+    workflowState.property1 = "something";
+
+    beforeAll(async () => {
+      await sut.saveWorkflowState(workflowState);
+    });
+
+    it("should add the row into the table", async () => {
+      const result = await collection.find().toArray();
+      expect(result.length).toEqual(1);
+      expect(result[0]).toMatchObject({
+        id: workflowState.$workflowId,
+        version: 1,
+        data: {
+          __workflowId: workflowState.$workflowId,
+          __status: WorkflowStatus.Running,
+          __version: 1,
+          __name: "TestWorkflowState",
+          eventValue: "abc",
+          property1: "something",
+        },
+      });
+    });
+
+    describe("when getting the workflow state by property", () => {
+      const testCommand = new TestCommand(workflowState.property1);
+      const messageOptions: MessageAttributes = {
+        attributes: {},
+        stickyAttributes: {},
+      };
+      let dataV1: TestWorkflowState;
+      let mapping: MessageWorkflowMapping<TestCommand, TestWorkflowState>;
+
+      it("should retrieve the item", async () => {
+        mapping = {
+          lookup: (message) => message.property1,
+          mapsTo: "property1",
+        };
+        const results = await sut.getWorkflowState(
+          TestWorkflowState,
+          mapping,
+          testCommand,
+          messageOptions
+        );
+        expect(results).toHaveLength(1);
+        dataV1 = results[0];
+        expect(dataV1).toMatchObject({ ...workflowState, $version: 1 });
+      });
+
+      describe("when updating the workflow state", () => {
+        let updates: TestWorkflowState;
+        let dataV2: TestWorkflowState;
+
+        beforeAll(async () => {
+          updates = {
+            ...dataV1,
+            eventValue: "something else",
+          };
+          await sut.saveWorkflowState(updates);
+
+          const results = await sut.getWorkflowState(
+            TestWorkflowState,
+            mapping,
+            testCommand,
+            messageOptions
+          );
+          dataV2 = results[0];
+        });
+
+        it("should return the updates", () => {
+          expect(dataV2).toMatchObject({
+            ...updates,
+            $version: 2,
+          });
+        });
+      });
+      describe("when updating the workflow state with invalid version", () => {
+        let updates: TestWorkflowState;
+        let error: Error;
+
+        beforeAll(async () => {
+          updates = {
+            ...dataV1,
+            eventValue: "something else",
+          };
+          try {
+            await sut.saveWorkflowState(updates);
+          } catch (err) {
+            error = err;
+          }
+        });
+
+        it("should throw WorkflowStateNotFound", async () => {
+          expect(error).toBeInstanceOf(WorkflowStateNotFound);
+        });
+      });
+    });
+  });
+});

--- a/packages/bus-mongodb/src/mongodb-persistence.ts
+++ b/packages/bus-mongodb/src/mongodb-persistence.ts
@@ -1,0 +1,301 @@
+import {
+  ClassConstructor,
+  CoreDependencies,
+  Logger,
+  MessageWorkflowMapping,
+  Persistence,
+  WorkflowState,
+} from "@node-ts/bus-core";
+import { Message, MessageAttributes } from "@node-ts/bus-messages";
+import { Db, MongoClient } from "mongodb";
+import { MongodbConfiguration } from "./mongodb-configuration";
+import { WorkflowStateNotFound } from "./error";
+import { mapKeys } from "lodash";
+/**
+ * The name of the field that stores workflow state as JSON in the database row.
+ */
+const WORKFLOW_DATA_FIELD_NAME = "data";
+
+export class MongodbPersistence implements Persistence {
+  private coreDependencies: CoreDependencies;
+  private logger: Logger;
+  private database: Db | undefined;
+  constructor(
+    private readonly configuration: MongodbConfiguration,
+    private client: MongoClient | undefined = new MongoClient(
+      configuration.connection
+    )
+  ) {}
+
+  prepare(coreDependencies: CoreDependencies): void {
+    this.coreDependencies = coreDependencies;
+    this.logger = coreDependencies.loggerFactory(
+      "@node-ts/bus-persistence:mongodb-persistence"
+    );
+    this.client;
+  }
+
+  async initialize(): Promise<void> {
+    this.logger.info("Initializing mongodb persistence...");
+    if (this.client) {
+      await this.client?.connect();
+      this.database = this.client?.db(this.configuration.databaseName);
+    }
+    this.logger.info("Mongodb persistence initialized");
+  }
+
+  async dispose(): Promise<void> {
+    this.logger.info("Disposing Mongodb persistence...");
+    if (this.client) {
+      this.client.close();
+      this.client = undefined;
+    }
+    this.logger.info("Mongodb persistence disposed");
+  }
+
+  async initializeWorkflow<WorkflowStateType extends WorkflowState>(
+    workflowStateConstructor: ClassConstructor<WorkflowStateType>,
+    messageWorkflowMappings: MessageWorkflowMapping<Message, WorkflowState>[]
+  ): Promise<void> {
+    const workflowStateName = new workflowStateConstructor().$name;
+    this.logger.info("Initializing workflow", {
+      workflowState: workflowStateName,
+    });
+
+    const collectionName = resolveQualifiedTableName(workflowStateName);
+    await this.ensureCollectionExists(collectionName);
+    await this.ensureIndexesExist(collectionName, messageWorkflowMappings);
+  }
+
+  async getWorkflowState<
+    WorkflowStateType extends WorkflowState,
+    MessageType extends Message
+  >(
+    workflowStateConstructor: ClassConstructor<WorkflowStateType>,
+    messageMap: MessageWorkflowMapping<MessageType, WorkflowStateType>,
+    message: MessageType,
+    attributes: MessageAttributes,
+    includeCompleted = false
+  ): Promise<WorkflowStateType[]> {
+    this.logger.debug("Getting workflow state", {
+      workflowStateName: workflowStateConstructor.name,
+    });
+    const workflowStateName = new workflowStateConstructor().$name;
+    const tableName = resolveQualifiedTableName(workflowStateName);
+    const matcherValue = messageMap.lookup(message, attributes);
+    const workflowStateField = `${WORKFLOW_DATA_FIELD_NAME}.${normalizeProperty(
+      messageMap.mapsTo
+    )}`;
+    const collection = this.database?.collection(tableName);
+    const findObject = {
+      [workflowStateField]: matcherValue,
+    } as any;
+    if (!includeCompleted) {
+      findObject[
+        `${WORKFLOW_DATA_FIELD_NAME}.${normalizeProperty("$status")}`
+      ] = "running";
+    }
+    const documents = await collection?.find(findObject).toArray();
+    this.logger.debug("Querying workflow state", { findObject });
+
+    this.logger.debug("Got workflow state", {
+      resultsCount: documents?.length,
+    });
+
+    const rows = documents?.map((x) => x[WORKFLOW_DATA_FIELD_NAME]) as any[];
+    return rows
+      .map((row) => mapKeys(row, (value, key) => denormalizeProperty(key)))
+      .filter((workflowState) => workflowState !== undefined)
+      .map((workflowState) =>
+        this.coreDependencies.serializer.toClass(
+          workflowState!,
+          workflowStateConstructor
+        )
+      );
+  }
+
+  async saveWorkflowState<WorkflowStateType extends WorkflowState>(
+    workflowState: WorkflowStateType
+  ): Promise<void> {
+    this.logger.debug("Saving workflow state", {
+      workflowStateName: workflowState.$name,
+      id: workflowState.$workflowId,
+    });
+    const collectionName = resolveQualifiedTableName(workflowState.$name);
+
+    const oldVersion = workflowState.$version;
+    const newVersion = oldVersion + 1;
+    const modifiedState = mapKeys(workflowState, (value, key) => {
+      return normalizeProperty(key);
+    });
+    const plainWorkflowState = {
+      ...this.coreDependencies.serializer.toPlain(modifiedState),
+      __version: newVersion,
+    };
+
+    await this.upsertWorkflowState(
+      collectionName,
+      workflowState.$workflowId,
+      plainWorkflowState,
+      oldVersion,
+      newVersion
+    );
+  }
+
+  private async ensureCollectionExists(collectionName: string): Promise<void> {
+    this.logger.debug("Ensuring mongodb collection for workflow state exists", {
+      collectionName,
+    });
+    const collectionExists = await this.database
+      ?.listCollections({ name: collectionName }, { nameOnly: true })
+      .hasNext();
+    if (!collectionExists) {
+      await this.database?.createCollection(collectionName);
+    }
+  }
+
+  private async ensureIndexesExist(
+    collectionName: string,
+    messageWorkflowMappings: MessageWorkflowMapping<Message, WorkflowState>[]
+  ): Promise<void> {
+    const collection = this.database?.collection(collectionName);
+    const existingIndexes = (await collection?.listIndexes().toArray()) ?? [];
+    const existingIndexNames = existingIndexes?.map((index) => index.name);
+    const createPrimaryIndex = this.createPrimaryIndex(
+      collectionName,
+      existingIndexNames as string[]
+    );
+
+    const allWorkflowFields = messageWorkflowMappings.map(
+      (mapping) => mapping.mapsTo
+    );
+    const distinctWorkflowFields = new Set(allWorkflowFields);
+    const workflowFields: string[] = [...distinctWorkflowFields];
+
+    const createSecondaryIndexes = workflowFields.map(async (workflowField) => {
+      const indexName = resolveIndexName(collectionName, workflowField);
+      const existingIndexLocation = existingIndexNames.indexOf(indexName);
+      if (existingIndexLocation !== -1) {
+        this.logger.debug("Index already exists", { indexName });
+        existingIndexNames.splice(existingIndexLocation, 1);
+        return;
+      }
+      const workflowStateField = `${WORKFLOW_DATA_FIELD_NAME}.'${workflowField}'`;
+      this.logger.debug("Ensuring secondary index exists", {
+        indexName,
+      });
+      await collection?.createIndex(
+        { [workflowStateField]: 1 },
+        { name: indexName }
+      );
+    });
+    const dropIndexes = existingIndexNames.map(async (indexName) => {
+      await collection?.dropIndex(indexName);
+    });
+    await Promise.all([
+      createPrimaryIndex,
+      ...createSecondaryIndexes,
+      ...dropIndexes,
+    ]);
+  }
+
+  private async createPrimaryIndex(
+    collectionName: string,
+    existingIndexesNames: string[]
+  ): Promise<void> {
+    const collection = this.database?.collection(collectionName);
+    const primaryIndexName = resolveIndexName(collectionName, "id", "version");
+    const primaryIndexLocation = existingIndexesNames.indexOf(primaryIndexName);
+    if (primaryIndexLocation !== -1) {
+      existingIndexesNames.splice(primaryIndexLocation, 1);
+      return;
+    }
+    this.logger.debug("Ensuring primary index exists", {
+      primaryIndexName,
+    });
+    await collection?.createIndex(
+      { _id: 1, version: 1 },
+      { name: primaryIndexName }
+    );
+  }
+
+  private async upsertWorkflowState(
+    collectionName: string,
+    workflowId: string,
+    plainWorkflowState: object,
+    oldVersion: number,
+    newVersion: number
+  ): Promise<void> {
+    const collection = this.database?.collection(collectionName);
+    if (oldVersion === 0) {
+      this.logger.debug("Inserting new workflow state", {
+        collectionName,
+        workflowId,
+        oldVersion,
+        newVersion,
+      });
+      // This is a new workflow, so just insert the data
+      await collection?.insertOne({
+        id: workflowId,
+        version: newVersion,
+        [WORKFLOW_DATA_FIELD_NAME]: plainWorkflowState,
+      });
+    } else {
+      this.logger.debug("Updating existing workflow state", {
+        collectionName,
+        workflowId,
+        oldVersion,
+        newVersion,
+      });
+      const result = await collection?.findOneAndUpdate(
+        {
+          id: workflowId,
+          version: oldVersion,
+        },
+        {
+          $set: {
+            version: newVersion,
+            [WORKFLOW_DATA_FIELD_NAME]: plainWorkflowState,
+          },
+        }
+      );
+      if (!result?.value) {
+        throw new WorkflowStateNotFound(workflowId, collectionName, oldVersion);
+      }
+    }
+  }
+}
+
+/**
+ * Returns a legal fully qualified schema + table name
+ */
+function resolveQualifiedTableName(collectionName: string): string {
+  const invalidPostgresCharacters = /[^0-9a-zA-Z_.-]/g;
+  const normalizedTableName = collectionName
+    .replace(invalidPostgresCharacters, "")
+    .toLowerCase();
+  const formattedTableName = toSnakeCase(normalizedTableName);
+  return `${formattedTableName}`;
+}
+
+/**
+ * Converts pascal to snake case
+ * @example MyTableName => my_table_name
+ */
+function toSnakeCase(value: string): string {
+  return value.replace(/([A-Z])/g, (c) => `_${c.toLowerCase()}`);
+}
+
+/**
+ * Resolves the name of an index from the fields contained in that index
+ */
+function resolveIndexName(tableName: string, ...fields: string[]): string {
+  const normalizedTableName = tableName.replace(/"/g, "").replace(".", "_");
+  return `"${normalizedTableName}_${fields.join("_")}_idx"`;
+}
+function normalizeProperty(property: string): string {
+  return property.replace("$", "__");
+}
+function denormalizeProperty(property: string): string {
+  return property.replace("__", "$");
+}

--- a/packages/bus-mongodb/test/index.ts
+++ b/packages/bus-mongodb/test/index.ts
@@ -1,0 +1,5 @@
+export * from './test-workflow-state'
+export * from './test-command'
+export * from './test-workflow'
+export * from './task-ran'
+export * from './run-task'

--- a/packages/bus-mongodb/test/run-task.ts
+++ b/packages/bus-mongodb/test/run-task.ts
@@ -1,0 +1,13 @@
+import { Command } from '@node-ts/bus-messages'
+
+export class RunTask extends Command {
+  static NAME = '@node-ts/bus-core/run-task'
+  $name = RunTask.NAME
+  $version = 0
+
+  constructor (
+    readonly value: string
+  ) {
+    super()
+  }
+}

--- a/packages/bus-mongodb/test/task-ran.ts
+++ b/packages/bus-mongodb/test/task-ran.ts
@@ -1,0 +1,13 @@
+import { Event } from '@node-ts/bus-messages'
+
+export class TaskRan extends Event {
+  static NAME = '@node-ts/bus-core/task-ran'
+  $name = TaskRan.NAME
+  $version = 0
+
+  constructor (
+    readonly value: string
+  ) {
+    super()
+  }
+}

--- a/packages/bus-mongodb/test/test-command.ts
+++ b/packages/bus-mongodb/test/test-command.ts
@@ -1,0 +1,13 @@
+import { Command } from '@node-ts/bus-messages'
+
+export class TestCommand extends Command {
+  static NAME = '@node-ts/bus-core/test-command'
+  $name = TestCommand.NAME
+  $version = 0
+
+  constructor (
+    readonly property1: string | undefined
+  ) {
+    super()
+  }
+}

--- a/packages/bus-mongodb/test/test-workflow-state.ts
+++ b/packages/bus-mongodb/test/test-workflow-state.ts
@@ -1,0 +1,9 @@
+import { WorkflowState } from '@node-ts/bus-core'
+
+export class TestWorkflowState extends WorkflowState {
+  static NAME = 'TestWorkflowState'
+  $name = TestWorkflowState.NAME
+
+  property1: string
+  eventValue: string
+}

--- a/packages/bus-mongodb/test/test-workflow.ts
+++ b/packages/bus-mongodb/test/test-workflow.ts
@@ -1,0 +1,28 @@
+import { TestWorkflowState } from './test-workflow-state'
+import { Bus, HandlerContext, Workflow, WorkflowMapper } from '@node-ts/bus-core'
+import { TestCommand } from './test-command'
+import { RunTask } from './run-task'
+import { TaskRan } from './task-ran'
+
+export class TestWorkflow extends Workflow<TestWorkflowState> {
+
+  configureWorkflow(mapper: WorkflowMapper<TestWorkflowState, TestWorkflow>): void {
+    mapper
+      .withState(TestWorkflowState)
+      .startedBy(TestCommand, 'sendRunTask')
+      .when(TaskRan, 'complete', { lookup: ({ message }) => message.value, mapsTo: 'property1' })
+  }
+
+  async sendRunTask ({ message: { property1 } }: HandlerContext<TestCommand>): Promise<Partial<TestWorkflowState>> {
+    await Bus.send(new RunTask(property1!))
+    return {
+      property1
+    }
+  }
+
+  complete ({ message: { value } }: HandlerContext<TaskRan>): Partial<TestWorkflowState> {
+    return this.completeWorkflow({
+      eventValue: value
+    })
+  }
+}

--- a/packages/bus-mongodb/tsconfig.json
+++ b/packages/bus-mongodb/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.integration.ts",
+    "src/**/test"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./"
+  }
+}

--- a/packages/bus-mongodb/tslint.json
+++ b/packages/bus-mongodb/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "await-promise": [true, "Bluebird"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,6 +1565,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/lodash@^4.14.194":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -1635,6 +1640,19 @@
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+
+"@types/webidl-conversions@*":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz#2b8e60e33906459219aa587e9d1a612ae994cfe7"
+  integrity sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==
+
+"@types/whatwg-url@^8.2.1":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.2.tgz#749d5b3873e845897ada99be4448041d4cc39e63"
+  integrity sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==
+  dependencies:
+    "@types/node" "*"
+    "@types/webidl-conversions" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -2138,6 +2156,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+bson@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-5.2.0.tgz#c81d35dd30e2798203e5422a639780ea98dd25ba"
+  integrity sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -3799,6 +3822,11 @@ ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
+ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
+  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -4887,7 +4915,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4985,6 +5013,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
 
 meow@^7.0.0:
   version "7.1.1"
@@ -5222,6 +5255,25 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+mongodb-connection-string-url@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
+  dependencies:
+    "@types/whatwg-url" "^8.2.1"
+    whatwg-url "^11.0.0"
+
+mongodb@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.3.0.tgz#9bef3ff35511a66fb7d9aafb7b06112787138db1"
+  integrity sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==
+  dependencies:
+    bson "^5.2.0"
+    mongodb-connection-string-url "^2.6.0"
+    socks "^2.7.1"
+  optionalDependencies:
+    saslprep "^1.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -6440,6 +6492,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+saslprep@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -6561,7 +6620,7 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-smart-buffer@^4.1.0:
+smart-buffer@^4.1.0, smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -6612,6 +6671,14 @@ socks@^2.3.3:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
+
+socks@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  dependencies:
+    ip "^2.0.0"
+    smart-buffer "^4.2.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -6665,6 +6732,13 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
+  dependencies:
+    memory-pager "^1.0.2"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -7093,6 +7167,13 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -7451,6 +7532,11 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
 whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
@@ -7462,6 +7548,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.4.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
I was using the library workflow part and came across the case where I needed to use Mongodb as a persistence for states. 

High level changes: 
* Add new package for @node-ts/bus-mongodb.
* Add mongodb configuration.
* Add mongodb persistence.
* Add integration tests for mongodb.

@adenhertog  I have copied this implementation from bus-postgres package that exists in the project.