### PR TITLE
#212: Add persistent message flag to RabbitMQ.

### DIFF
--- a/packages/bus-rabbitmq/src/rabbitmq-transport-configuration.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport-configuration.ts
@@ -12,4 +12,9 @@ export interface RabbitMqTransportConfiguration extends TransportConfiguration {
    * @default 10
    */
   maxRetries?: number
+
+  /**
+   * Whether the messages in RabbitMQ are persistent or not (survive a broker restart). By default, false.
+   */
+  persistentMessages?: number
 }

--- a/packages/bus-rabbitmq/src/rabbitmq-transport.ts
+++ b/packages/bus-rabbitmq/src/rabbitmq-transport.ts
@@ -51,6 +51,7 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
 
   private consumptionQueue: ConsumeMessage[] = []
   private consumptionQueueEvents = new EventEmitter()
+  private persistentMessages: boolean
 
   constructor(private readonly configuration: RabbitMqTransportConfiguration) {
     this.maxRetries = configuration.maxRetries ?? DEFAULT_MAX_RETRIES
@@ -59,6 +60,7 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     this.retryQueue = `${configuration.queueName}-retry`
     this.retryQueueExchange = `${configuration.queueName}-retry`
     this.serviceQueueExchange = configuration.queueName
+    this.persistentMessages = configuration.persistentMessages ?? false
   }
 
   prepare(coreDependencies: CoreDependencies): void {
@@ -363,6 +365,7 @@ export class RabbitMqTransport implements Transport<RabbitMqMessage> {
     this.channel.publish(message.$name, '', Buffer.from(payload), {
       correlationId: messageOptions.correlationId,
       messageId: uuid.v4(),
+      persistent: this.persistentMessages,
       headers: {
         attributes: messageOptions.attributes
           ? JSON.stringify(messageOptions.attributes)


### PR DESCRIPTION
Since messages are not persistent by default in RabbitMQ, this PR allows the consumers of the library to pass this flag to RabbitMQ transport configuration.  

* Add a new flag to RabbitMQTransportConfiguration.
* Use the persistent flag when publishing messages to RabbitMQ exchange.