### PR TITLE
Replace async_hooks with cli-hooked

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-ts/bus-core",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A service bus for message-based, distributed node applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "workspace:^",
+    "cls-hooked": "^4.2.2",
     "debug": "^4.3.4",
     "reflect-metadata": "^0.1.13",
     "serialize-error": "8",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@node-ts/code-standards": "^0.0.10",
+    "@types/cls-hooked": "^4.3.8",
     "@types/debug": "^4.1.5",
     "@types/faker": "^4.1.5",
     "@types/node": "^18.19.10",

--- a/packages/bus-core/src/message-handling-context/message-handling-context.ts
+++ b/packages/bus-core/src/message-handling-context/message-handling-context.ts
@@ -1,4 +1,9 @@
-import { createNamespace, destroyNamespace, Namespace } from 'cls-hooked'
+import {
+  createNamespace,
+  destroyNamespace,
+  getNamespace,
+  Namespace
+} from 'cls-hooked'
 import { TransportMessage } from '../transport'
 
 const NAMESPACE = 'message-handling-context'
@@ -34,5 +39,9 @@ export const messageHandlingContext = {
   /**
    * Stops tracking the current execution context.
    */
-  disable: () => destroyNamespace(NAMESPACE)
+  disable: () => {
+    if (getNamespace(NAMESPACE)) {
+      destroyNamespace(NAMESPACE)
+    }
+  }
 }

--- a/packages/bus-core/src/message-handling-context/message-handling-context.ts
+++ b/packages/bus-core/src/message-handling-context/message-handling-context.ts
@@ -1,40 +1,8 @@
-import * as asyncHooks from 'async_hooks'
+import { createNamespace, destroyNamespace, Namespace } from 'cls-hooked'
 import { TransportMessage } from '../transport'
 
-interface HandlingContext {
-  /**
-   * A list of child async process ids that are running in the same execution context
-   * and need to be destroyed when the parent is destroyed.
-   *
-   * This can be handled with regular destroy hooks, however this is subject to GC
-   * and runs the risk of keeping a large number of contexts open after their parent
-   * context has closed.
-   */
-  childAsyncIds: number[]
-  message: TransportMessage<unknown>
-}
-
-const handlingContexts = new Map<number, HandlingContext>()
-
-const init = (asyncId: number, _: string, triggerAsyncId: number) => {
-  // Ensures that child promises inherit the same context as their parent
-  if (handlingContexts.has(triggerAsyncId)) {
-    const context = handlingContexts.get(triggerAsyncId)!
-    context.childAsyncIds.push(asyncId)
-    handlingContexts.set(asyncId, context)
-  }
-}
-
-const destroy = (asyncId: number) => {
-  if (handlingContexts.has(asyncId)) {
-    handlingContexts.delete(asyncId)
-  }
-}
-
-const hooks = asyncHooks.createHook({
-  init,
-  destroy
-})
+const NAMESPACE = 'message-handling-context'
+let namespace: Namespace
 
 /**
  * This is an internal coordinator that tracks the execution context for
@@ -46,27 +14,25 @@ const hooks = asyncHooks.createHook({
  */
 export const messageHandlingContext = {
   /**
+   * Executes a function within a context of cls-hooked
+   */
+  run: (fn: (...args: any[]) => void) => namespace.run(fn),
+  /**
    * Sets a new handling context for the current execution async id. Child asyncs should
    * only call this if they want to create a new context with themselves at the root.
    */
   set: (message: TransportMessage<unknown>) =>
-    handlingContexts.set(asyncHooks.executionAsyncId(), {
-      childAsyncIds: [],
-      message
-    }),
-  get: () => handlingContexts.get(asyncHooks.executionAsyncId()),
-  destroy: () => {
-    const asyncId = asyncHooks.executionAsyncId()
-    const context = handlingContexts.get(asyncId)
-    if (!context) {
-      return
-    }
-
-    context.childAsyncIds.forEach(childAsyncId =>
-      handlingContexts.delete(childAsyncId)
-    )
-    handlingContexts.delete(asyncId)
-  },
-  enable: () => hooks.enable(),
-  disable: () => hooks.disable()
+    namespace.set('message', message),
+  /**
+   * Fetches the message handling context of the active async stack
+   */
+  get: () => namespace.get('message') as TransportMessage<unknown>,
+  /**
+   * Hooks into the async_hooks module to track the current execution context. Must be called before other operations.
+   */
+  enable: () => (namespace = createNamespace(NAMESPACE)),
+  /**
+   * Stops tracking the current execution context.
+   */
+  disable: () => destroyNamespace(NAMESPACE)
 }

--- a/packages/bus-core/src/message-handling-context/message-handling-context.ts
+++ b/packages/bus-core/src/message-handling-context/message-handling-context.ts
@@ -22,11 +22,11 @@ export const messageHandlingContext = {
    * only call this if they want to create a new context with themselves at the root.
    */
   set: (message: TransportMessage<unknown>) =>
-    namespace.set('message', message),
+    namespace?.set('message', message),
   /**
    * Fetches the message handling context of the active async stack
    */
-  get: () => namespace.get('message') as TransportMessage<unknown>,
+  get: () => namespace?.get('message') as TransportMessage<unknown>,
   /**
    * Hooks into the async_hooks module to track the current execution context. Must be called before other operations.
    */

--- a/packages/bus-core/src/workflow/started.spec.ts
+++ b/packages/bus-core/src/workflow/started.spec.ts
@@ -169,8 +169,8 @@ describe('Workflow', () => {
       .build()
 
     await bus.initialize()
-    await bus.send(event)
     await bus.start()
+    await bus.send(event)
     await sleep(CONSUME_TIMEOUT)
   })
 

--- a/packages/bus-core/src/workflow/workflow-concurrency.integration.ts
+++ b/packages/bus-core/src/workflow/workflow-concurrency.integration.ts
@@ -1,0 +1,124 @@
+import { It, Mock, Times } from 'typemoq'
+import { Handler, Workflow, WorkflowMapper, WorkflowState } from '../'
+import { Bus, BusInstance } from '../service-bus'
+import { ClassConstructor, sleep } from '../util'
+import { InMemoryPersistence } from './persistence'
+import {
+  FinalTask,
+  RunTask,
+  TaskRan,
+  TestCommand,
+  TestWorkflowState
+} from './test'
+import { MessageAttributes } from '@node-ts/bus-messages'
+import * as uuid from 'uuid'
+
+jest.setTimeout(10_000)
+
+describe('Workflow Concurrency', () => {
+  const completeCallback =
+    Mock.ofType<(workflowId: string, correlationId: string) => void>()
+
+  class TestWorkflow extends Workflow<TestWorkflowState> {
+    constructor(private bus: BusInstance) {
+      super()
+    }
+
+    configureWorkflow(
+      mapper: WorkflowMapper<TestWorkflowState, TestWorkflow>
+    ): void {
+      mapper
+        .withState(TestWorkflowState)
+        .startedBy(TestCommand, 'step1')
+        .when(TaskRan, 'step2', {
+          lookup: message => message.value,
+          mapsTo: 'property1'
+        })
+        .when(FinalTask, 'step3') // Maps on workflow id
+    }
+
+    async step1({ property1 }: TestCommand, _: any) {
+      await this.bus.send(new RunTask(property1!))
+      return { property1 }
+    }
+
+    async step2({ value }: TaskRan, state: TestWorkflowState) {
+      await this.bus.send(new FinalTask())
+      return { ...state, property1: value }
+    }
+
+    async step3(
+      _: FinalTask,
+      __: WorkflowState,
+      {
+        correlationId,
+        stickyAttributes: { workflowId }
+      }: MessageAttributes<{}, { workflowId: string }>
+    ) {
+      completeCallback.object(workflowId, correlationId!)
+      return this.completeWorkflow()
+    }
+  }
+
+  class RunTaskHandler implements Handler<RunTask> {
+    messageType = RunTask
+
+    constructor(private bus: BusInstance) {}
+
+    async handle(message: RunTask) {
+      await this.bus.publish(new TaskRan(message.value))
+    }
+  }
+
+  const CONSUME_TIMEOUT = 5_000
+  let bus: BusInstance
+  const inMemoryPersistence = new InMemoryPersistence()
+  const workflowsToInvoke = 100
+  const correlationIds = new Array(workflowsToInvoke)
+    .fill(undefined)
+    .map(() => uuid.v4())
+
+  beforeAll(async () => {
+    bus = Bus.configure()
+      .withPersistence(inMemoryPersistence)
+      .withContainer({
+        get<T>(ctor: ClassConstructor<T>) {
+          return new ctor(bus)
+        }
+      })
+      .withWorkflow(TestWorkflow)
+      .withHandler(RunTaskHandler)
+      .withConcurrency(10)
+      .build()
+
+    await bus.initialize()
+    await bus.start()
+
+    // Introduce sufficient parallelism to test for message handling context leakage
+    const sendMessages = correlationIds.map(
+      async (correlationId: string) =>
+        await bus.send(new TestCommand(uuid.v4()), { correlationId })
+    )
+    await Promise.all(sendMessages)
+    await sleep(CONSUME_TIMEOUT)
+  })
+
+  afterAll(async () => {
+    await bus.dispose()
+  })
+
+  describe('when a message that starts a workflow is received', () => {
+    it('should complete the workflow', () => {
+      correlationIds.forEach(correlationId =>
+        completeCallback.verify(
+          c =>
+            c(
+              It.is(workflowId => !!workflowId),
+              correlationId
+            ),
+          Times.once()
+        )
+      )
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@node-ts/bus-messages':
         specifier: workspace:^
         version: link:../bus-messages
+      cls-hooked:
+        specifier: ^4.2.2
+        version: 4.2.2
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@9.0.2)
@@ -93,6 +96,9 @@ importers:
       '@node-ts/code-standards':
         specifier: ^0.0.10
         version: 0.0.10
+      '@types/cls-hooked':
+        specifier: ^4.3.8
+        version: 4.3.8
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.7
@@ -2135,6 +2141,12 @@ packages:
     resolution: {integrity: sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==}
     dev: true
 
+  /@types/cls-hooked@4.3.8:
+    resolution: {integrity: sha512-tf/7H883gFA6MPlWI15EQtfNZ+oPL0gLKkOlx9UHFrun1fC/FkuyNBpTKq1B5E3T4fbvjId6WifHUdSGsMMuPg==}
+    dependencies:
+      '@types/node': 18.19.10
+    dev: true
+
   /@types/debug@4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -2339,6 +2351,13 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /async-hook-jl@1.7.6:
+    resolution: {integrity: sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==}
+    engines: {node: ^4.7 || >=6.9 || >=7.3}
+    dependencies:
+      stack-chain: 1.3.7
+    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.23.9)(supports-color@9.0.2):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2575,6 +2594,15 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /cls-hooked@4.2.2:
+    resolution: {integrity: sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==}
+    engines: {node: ^4.7 || >=6.9 || >=7.3 || >=8.2.1}
+    dependencies:
+      async-hook-jl: 1.7.6
+      emitter-listener: 1.1.2
+      semver: 5.7.2
+    dev: false
+
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -2725,6 +2753,12 @@ packages:
   /electron-to-chromium@1.4.651:
     resolution: {integrity: sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==}
     dev: true
+
+  /emitter-listener@1.1.2:
+    resolution: {integrity: sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==}
+    dependencies:
+      shimmer: 1.2.1
+    dev: false
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -4166,6 +4200,11 @@ packages:
     dev: false
     optional: true
 
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: false
+
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4196,6 +4235,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
+
+  /shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+    dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -4278,6 +4321,10 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
+
+  /stack-chain@1.3.7:
+    resolution: {integrity: sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==}
+    dev: false
 
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}


### PR DESCRIPTION
Replaces the 'async_hooks' implementation of 'message-handling-context' with 'cli-hooked'.

There's a suspicion that the message-handling-context is leaking message contexts when used in highly parallel services. This can cause issued with handlers that depend on message attributes, particularly workflows that are mapped using correlationIds, to become out of sync.

'cli-hooked' has been integrated, which under the hood still uses the native node 'async_hooks', however does it in a much better tested and solid way. 

Tests have been introduced to illustrate that no context has been leaked when running multiple instances of a workflow in parallel.