### PR TITLE
Cutover message handling context to ALS Context

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-ts/bus-core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A service bus for message-based, distributed node applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@node-ts/bus-messages": "workspace:^",
-    "cls-hooked": "^4.2.2",
+    "alscontext": "^0.0.3",
     "debug": "^4.3.4",
     "reflect-metadata": "^0.1.13",
     "serialize-error": "8",
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@node-ts/code-standards": "^0.0.10",
-    "@types/cls-hooked": "^4.3.8",
     "@types/debug": "^4.1.5",
     "@types/faker": "^4.1.5",
     "@types/node": "^18.19.10",

--- a/packages/bus-core/src/message-handling-context/message-handling-context.ts
+++ b/packages/bus-core/src/message-handling-context/message-handling-context.ts
@@ -1,48 +1,27 @@
-import {
-  createNamespace,
-  destroyNamespace,
-  getNamespace,
-  Namespace
-} from 'cls-hooked'
 import { TransportMessage } from '../transport'
+import ALS from 'alscontext'
 
-const NAMESPACE = 'message-handling-context'
-let namespace: Namespace
-
-/**
- * This is an internal coordinator that tracks the execution context for
- * a message handling operation across multiple nested promises/callbacks as a way
- * of providing a type of thread local storage (TLS).
- *
- * It's primarily used to allow Bus.send/Bus.publish to propagate sticky attributes
- * and correlation ids in parallel handling contexts.
- */
-export const messageHandlingContext = {
+class MessageHandlingContext extends ALS {
   /**
-   * Executes a function within a context of cls-hooked and returns the result
+   * Fetch the message context for the current async stack
    */
-  runAndReturn: <T>(fn: (...args: any[]) => T) => namespace.runAndReturn(fn),
+  get(): TransportMessage<unknown> {
+    return super.get('message')
+  }
 
   /**
-   * Sets a new handling context for the current execution async id. Child asyncs should
-   * only call this if they want to create a new context with themselves at the root.
+   * Set the message context for the current async stack
    */
-  set: (message: TransportMessage<unknown>) =>
-    namespace?.set('message', message),
+  set(message: TransportMessage<unknown>) {
+    return super.set('message', message)
+  }
+
   /**
-   * Fetches the message handling context of the active async stack
+   * Start and run a new async context
    */
-  get: () => namespace?.get('message') as TransportMessage<unknown>,
-  /**
-   * Hooks into the async_hooks module to track the current execution context. Must be called before other operations.
-   */
-  enable: () => (namespace = createNamespace(NAMESPACE)),
-  /**
-   * Stops tracking the current execution context.
-   */
-  disable: () => {
-    if (getNamespace(NAMESPACE)) {
-      destroyNamespace(NAMESPACE)
-    }
+  run<T>(context: TransportMessage<unknown>, fn: () => T | Promise<T>) {
+    return super.run({ message: context }, fn)
   }
 }
+
+export const messageHandlingContext = new MessageHandlingContext()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,9 @@ importers:
       '@node-ts/bus-messages':
         specifier: workspace:^
         version: link:../bus-messages
-      cls-hooked:
-        specifier: ^4.2.2
-        version: 4.2.2
+      alscontext:
+        specifier: ^0.0.3
+        version: 0.0.3
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@9.0.2)
@@ -96,9 +96,6 @@ importers:
       '@node-ts/code-standards':
         specifier: ^0.0.10
         version: 0.0.10
-      '@types/cls-hooked':
-        specifier: ^4.3.8
-        version: 4.3.8
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.7
@@ -2141,12 +2138,6 @@ packages:
     resolution: {integrity: sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==}
     dev: true
 
-  /@types/cls-hooked@4.3.8:
-    resolution: {integrity: sha512-tf/7H883gFA6MPlWI15EQtfNZ+oPL0gLKkOlx9UHFrun1fC/FkuyNBpTKq1B5E3T4fbvjId6WifHUdSGsMMuPg==}
-    dependencies:
-      '@types/node': 18.19.10
-    dev: true
-
   /@types/debug@4.1.7:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
@@ -2276,6 +2267,11 @@ packages:
       indent-string: 4.0.0
     dev: true
 
+  /alscontext@0.0.3:
+    resolution: {integrity: sha512-7MqsMB7f0AkNJf9UbCfbPL+5t2J0nMSKdSFUuo3MEWFhG5WOOEqqg5J1nuNlNlLj1u189PgQwMSrr515ffQxcg==}
+    engines: {node: '>=8.12.0'}
+    dev: false
+
   /amqplib@0.10.3(supports-color@9.0.2):
     resolution: {integrity: sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==}
     engines: {node: '>=10'}
@@ -2351,13 +2347,6 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
     dev: true
-
-  /async-hook-jl@1.7.6:
-    resolution: {integrity: sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==}
-    engines: {node: ^4.7 || >=6.9 || >=7.3}
-    dependencies:
-      stack-chain: 1.3.7
-    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.23.9)(supports-color@9.0.2):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2594,15 +2583,6 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /cls-hooked@4.2.2:
-    resolution: {integrity: sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==}
-    engines: {node: ^4.7 || >=6.9 || >=7.3 || >=8.2.1}
-    dependencies:
-      async-hook-jl: 1.7.6
-      emitter-listener: 1.1.2
-      semver: 5.7.2
-    dev: false
-
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -2753,12 +2733,6 @@ packages:
   /electron-to-chromium@1.4.651:
     resolution: {integrity: sha512-jjks7Xx+4I7dslwsbaFocSwqBbGHQmuXBJUK9QBZTIrzPq3pzn6Uf2szFSP728FtLYE3ldiccmlkOM/zhGKCpA==}
     dev: true
-
-  /emitter-listener@1.1.2:
-    resolution: {integrity: sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==}
-    dependencies:
-      shimmer: 1.2.1
-    dev: false
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -4200,11 +4174,6 @@ packages:
     dev: false
     optional: true
 
-  /semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-    dev: false
-
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4235,10 +4204,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
-
-  /shimmer@1.2.1:
-    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
-    dev: false
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -4321,10 +4286,6 @@ packages:
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
-
-  /stack-chain@1.3.7:
-    resolution: {integrity: sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==}
-    dev: false
 
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}


### PR DESCRIPTION
Removes cls-hooked and replaces with alscontext

The cls-hooked library is unmaintained, and when used with promises/async fails to dispose the context correctly and leaks memory.

- https://github.com/Jeff-Lewis/cls-hooked/issues/63
- https://github.com/Jeff-Lewis/cls-hooked/issues/66

`alscontext` is used in this change, which from observation doesn't have the same issue.