### PR TITLE
Upgrade 'no existing workflow state' log from warn to error

### DIFF
--- a/packages/bus-core/src/workflow/registry/workflow-registry.ts
+++ b/packages/bus-core/src/workflow/registry/workflow-registry.ts
@@ -269,7 +269,7 @@ export class WorkflowRegistry {
           )
 
           if (!workflowState.length) {
-            this.logger.warn(
+            this.logger.error(
               'No existing workflow state found for message. Ignoring.',
               { busMessage: message, attributes }
             )


### PR DESCRIPTION
This PR upgrades the current log from warn to error so that it hits our production logs for greater visibility.