### PR TITLE
Fix .discard() still persisting workflow data

### DIFF
--- a/packages/bus-core/src/workflow/test/test-discarded-workflow.ts
+++ b/packages/bus-core/src/workflow/test/test-discarded-workflow.ts
@@ -1,0 +1,20 @@
+import { Workflow, WorkflowMapper } from '../workflow'
+import { WorkflowState } from '../workflow-state'
+import { TestCommand } from './test-command'
+
+export class TestDiscardedWorkflowState extends WorkflowState {
+  static NAME = 'TestDiscardedWorkflowState'
+  $name = TestDiscardedWorkflowState.NAME
+}
+
+export class TestDiscardedWorkflow extends Workflow<TestDiscardedWorkflowState> {
+  configureWorkflow(
+    mapper: WorkflowMapper<TestDiscardedWorkflowState, any>
+  ): void {
+    mapper.withState(TestDiscardedWorkflowState).startedBy(TestCommand, 'step1')
+  }
+
+  async step1() {
+    return this.discardWorkflow()
+  }
+}

--- a/packages/bus-core/src/workflow/test/test-void-startedby-workflow.ts
+++ b/packages/bus-core/src/workflow/test/test-void-startedby-workflow.ts
@@ -1,0 +1,22 @@
+import { Workflow, WorkflowMapper } from '../workflow'
+import { WorkflowState } from '../workflow-state'
+import { TestCommand } from './test-command'
+
+export class TestVoidStartedByWorkflowState extends WorkflowState {
+  static NAME = 'TestVoidStartedByWorkflowState'
+  $name = TestVoidStartedByWorkflowState.NAME
+}
+
+export class TestVoidStartedByWorkflow extends Workflow<TestVoidStartedByWorkflowState> {
+  configureWorkflow(
+    mapper: WorkflowMapper<TestVoidStartedByWorkflowState, any>
+  ): void {
+    mapper
+      .withState(TestVoidStartedByWorkflowState)
+      .startedBy(TestCommand, 'step1')
+  }
+
+  async step1() {
+    // ...
+  }
+}

--- a/packages/bus-core/src/workflow/workflow-startedby.integration.ts
+++ b/packages/bus-core/src/workflow/workflow-startedby.integration.ts
@@ -1,0 +1,73 @@
+import { Bus, BusInstance } from '../service-bus'
+import { sleep } from '../util'
+import { InMemoryPersistence } from './persistence'
+import { TestCommand } from './test'
+import {
+  TestDiscardedWorkflow,
+  TestDiscardedWorkflowState
+} from './test/test-discarded-workflow'
+import { It, Mock, Times } from 'typemoq'
+import {
+  TestVoidStartedByWorkflow,
+  TestVoidStartedByWorkflowState
+} from './test/test-void-startedby-workflow'
+
+describe('Workflow Started By', () => {
+  const inMemoryPersistence = Mock.ofType<InMemoryPersistence>()
+  let bus: BusInstance
+
+  beforeAll(async () => {
+    bus = Bus.configure()
+      .withPersistence(inMemoryPersistence.object)
+      .withWorkflow(TestDiscardedWorkflow)
+      .withWorkflow(TestVoidStartedByWorkflow)
+      .build()
+
+    await bus.initialize()
+    await bus.start()
+  })
+
+  afterAll(async () => {
+    bus.dispose()
+  })
+
+  describe('when a workflow that discards during startedBy is executed', () => {
+    beforeEach(async () => {
+      inMemoryPersistence.reset()
+      await bus.send(new TestCommand('abc'))
+      await sleep(2_000)
+    })
+
+    it('should not persist any workflow state', async () => {
+      inMemoryPersistence.verify(
+        p =>
+          p.saveWorkflowState(
+            It.isObjectWith<any>({
+              $name: TestDiscardedWorkflowState.NAME
+            })
+          ),
+        Times.never()
+      )
+    })
+  })
+
+  describe('when a workflow that returns void during startedBy is executed', () => {
+    beforeEach(async () => {
+      inMemoryPersistence.reset()
+      await bus.send(new TestCommand('abc'))
+      await sleep(2_000)
+    })
+
+    it('should persist workflow state', async () => {
+      inMemoryPersistence.verify(
+        p =>
+          p.saveWorkflowState(
+            It.isObjectWith<any>({
+              $name: TestVoidStartedByWorkflowState.NAME
+            })
+          ),
+        Times.once()
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes `this.discard()` not discarding workflow changes, particularly in startedBy handlers where workflow state should not be persisted.

Previously a workflow state was still being written to persistence when calling this, which was incorrect.