### PR TITLE
Dispatch outbox using worker queue

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-ts/bus-core",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "A service bus for message-based, distributed node applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds messages to an in-memory array as the outbox queue, and dispatches using a worker pool

Previously for handlers that sent high volumes of messages (eg, 10K+), the messages would be outboxed as anon async functions. These were previously dispatched using a single Promise.all(), which causes heap exhaustion particularly in low-mem environments.

This update provides the same final behaviour, but does it in a more memory-efficient way.