### PR TITLE
Expose `bus.returnMessage()`

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-ts/bus-core",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "description": "A service bus for message-based, distributed node applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/bus-core/src/error/fail-message-outside-handling-context.ts
+++ b/packages/bus-core/src/error/fail-message-outside-handling-context.ts
@@ -1,10 +1,10 @@
 export class FailMessageOutsideHandlingContext extends Error {
   constructor(
-    readonly help = `Calling .fail() with a message indicates that the message received from the
+    readonly help = `Calling .failMessage() with a message indicates that the message received from the
 queue can not be processed even with retries and should immediately be sent
 to the dead letter queue.
 
-This error occurs when .fail() has been called outside of a message handling context,
+This error occurs when .failMessage() has been called outside of a message handling context,
 or more specifically - outside the stack of a Handler() operation`
   ) {
     super(`Attempted to fail message outside of a message handling context`)

--- a/packages/bus-core/src/error/index.ts
+++ b/packages/bus-core/src/error/index.ts
@@ -1,3 +1,4 @@
 export * from './fail-message-outside-handling-context'
 export * from './class-handler-not-resolved'
 export * from './container-not-registered'
+export * from './return-message-outside-handling-context'

--- a/packages/bus-core/src/error/return-message-outside-handling-context.ts
+++ b/packages/bus-core/src/error/return-message-outside-handling-context.ts
@@ -1,0 +1,12 @@
+export class ReturnMessageOutsideHandlingContext extends Error {
+  constructor(
+    readonly help = `Calling .return() with a message indicates that the message received from the
+queue should be returned so it can be retried.
+
+This error occurs when .return() has been called outside of a message handling context,
+or more specifically - outside the stack of a Handler() operation`
+  ) {
+    super(`Attempted to return message outside of a message handling context`)
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/packages/bus-core/src/error/return-message-outside-handling-context.ts
+++ b/packages/bus-core/src/error/return-message-outside-handling-context.ts
@@ -1,9 +1,9 @@
 export class ReturnMessageOutsideHandlingContext extends Error {
   constructor(
-    readonly help = `Calling .return() with a message indicates that the message received from the
+    readonly help = `Calling .returnMessage() with a message indicates that the message received from the
 queue should be returned so it can be retried.
 
-This error occurs when .return() has been called outside of a message handling context,
+This error occurs when .returnMessage() has been called outside of a message handling context,
 or more specifically - outside the stack of a Handler() operation`
   ) {
     super(`Attempted to return message outside of a message handling context`)

--- a/packages/bus-core/src/message-lifecycle-context/index.ts
+++ b/packages/bus-core/src/message-lifecycle-context/index.ts
@@ -1,0 +1,1 @@
+export * from './message-lifecycle-context'

--- a/packages/bus-core/src/message-lifecycle-context/message-lifecycle-context.ts
+++ b/packages/bus-core/src/message-lifecycle-context/message-lifecycle-context.ts
@@ -1,0 +1,45 @@
+import ALS from 'alscontext'
+
+type Context = {
+  messageReturnedToQueue: boolean
+}
+
+/**
+ * An internal context that tracks calls within handlers to .returnMessage()
+ */
+class MessageLifecycleContext extends ALS {
+  /**
+   * Fetch the message context for the current async stack
+   */
+  get(): Context {
+    return super.get('message')
+  }
+
+  /**
+   * Set the message context for the current async stack
+   */
+  set(message: Context) {
+    return super.set('message', message)
+  }
+
+  /**
+   * Start and run a new async context
+   */
+  run<T>(
+    context: Context,
+    fn: () => T | Promise<T>,
+    isInHandlerContext = false
+  ): T | Promise<T> {
+    return super.run({ message: context, isInHandlerContext }, fn)
+  }
+
+  /**
+   * Check if the call stack is within a handler or workflow handler context
+   */
+  get isInHandlerContext(): boolean {
+    const isInHandlerContext = super.get('isInHandlerContext')
+    return isInHandlerContext === true
+  }
+}
+
+export const messageLifecycleContext = new MessageLifecycleContext()

--- a/packages/bus-core/src/service-bus/bus-instance-return-message.integration.ts
+++ b/packages/bus-core/src/service-bus/bus-instance-return-message.integration.ts
@@ -1,0 +1,56 @@
+import { Mock, Times } from 'typemoq'
+import { ReturnMessageOutsideHandlingContext } from '../error'
+import { handlerFor } from '../handler'
+import { TestCommand } from '../test/test-command'
+import { Bus } from './bus'
+import { BusInstance } from './bus-instance'
+import { sleep } from '../util'
+
+describe('BusInstance - Return Message', () => {
+  let bus: BusInstance
+  let invocationCount = 0
+  const callback = Mock.ofType<() => undefined>()
+
+  beforeAll(async () => {
+    bus = Bus.configure()
+      .withHandler(
+        handlerFor(TestCommand, async (_: TestCommand) => {
+          invocationCount++
+          callback.object()
+
+          if (invocationCount < 3) {
+            await bus.returnMessage()
+          }
+        })
+      )
+      .build()
+
+    await bus.initialize()
+    await bus.start()
+  })
+
+  afterAll(async () => {
+    await bus.dispose()
+  })
+
+  describe('when a message is returned to the queue during handling', () => {
+    beforeAll(async () => {
+      await bus.send(new TestCommand())
+      while (invocationCount < 3) {
+        await sleep(10)
+      }
+    })
+
+    it('should be returned to the queue and retry', async () => {
+      callback.verify(c => c(), Times.exactly(3))
+    })
+  })
+
+  describe('when a message is returned to the queue outside of a handler', () => {
+    it('should throw an error', async () => {
+      await expect(bus.returnMessage()).rejects.toBeInstanceOf(
+        ReturnMessageOutsideHandlingContext
+      )
+    })
+  })
+})

--- a/packages/bus-core/src/service-bus/bus-instance.integration.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.integration.ts
@@ -422,7 +422,7 @@ describe('BusInstance', () => {
         let bus: BusInstance | undefined
         try {
           bus = Bus.configure().build()
-          await bus.fail()
+          await bus.failMessage()
           fail('Expected FailMessageOutsideHandlingContext to have been thrown')
         } catch (error) {
           expect(error).toBeInstanceOf(FailMessageOutsideHandlingContext)
@@ -444,7 +444,7 @@ describe('BusInstance', () => {
           .withTransport(queue)
           .withHandler(
             handlerFor(TestCommand, async () => {
-              await bus.fail()
+              await bus.failMessage()
               events.emit('event')
             })
           )

--- a/packages/bus-core/src/service-bus/bus-instance.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.ts
@@ -237,7 +237,7 @@ export class BusInstance<TTransportMessage = {}> {
       throw new FailMessageOutsideHandlingContext()
     }
     this.logger.debug('Failing message', { message })
-    return this.transport.fail(message)
+    return this.transport.failMessage(message)
   }
 
   /**

--- a/packages/bus-core/src/service-bus/bus-instance.ts
+++ b/packages/bus-core/src/service-bus/bus-instance.ts
@@ -237,7 +237,7 @@ export class BusInstance<TTransportMessage = {}> {
       throw new FailMessageOutsideHandlingContext()
     }
     this.logger.debug('Failing message', { message })
-    return this.transport.failMessage(message)
+    return this.transport.fail(message)
   }
 
   /**

--- a/packages/bus-core/src/transport/in-memory-queue.spec.ts
+++ b/packages/bus-core/src/transport/in-memory-queue.spec.ts
@@ -188,7 +188,7 @@ describe('InMemoryQueue', () => {
     beforeEach(async () => {
       await sut.publish(message)
       const receivedMessage = await sut.readNextMessage()
-      await sut.failMessage(receivedMessage!)
+      await sut.fail(receivedMessage!)
     })
 
     it('should forward it to the dead letter queue', () => {

--- a/packages/bus-core/src/transport/in-memory-queue.spec.ts
+++ b/packages/bus-core/src/transport/in-memory-queue.spec.ts
@@ -188,7 +188,7 @@ describe('InMemoryQueue', () => {
     beforeEach(async () => {
       await sut.publish(message)
       const receivedMessage = await sut.readNextMessage()
-      await sut.fail(receivedMessage!)
+      await sut.failMessage(receivedMessage!)
     })
 
     it('should forward it to the dead letter queue', () => {
@@ -202,7 +202,7 @@ describe('InMemoryQueue', () => {
         .withHandler(
           handlerFor(TestEvent, async () => {
             await bus.send(new TestCommand())
-            await bus.fail()
+            await bus.failMessage()
           })
         )
         .withHandler(

--- a/packages/bus-core/src/transport/in-memory-queue.ts
+++ b/packages/bus-core/src/transport/in-memory-queue.ts
@@ -144,7 +144,7 @@ export class InMemoryQueue implements Transport<InMemoryMessage> {
   ): Promise<void> {
     const messageIndex = this.queue.indexOf(message)
     if (messageIndex < 0) {
-      // actions like .fail() will cause the message to already be deleted
+      // actions like .failMessage() will cause the message to already be deleted
       this.logger.debug('Message already deleted', { message, messageIndex })
       return
     }

--- a/packages/bus-core/src/transport/transport.ts
+++ b/packages/bus-core/src/transport/transport.ts
@@ -64,7 +64,7 @@ export interface Transport<TransportMessageType = {}> {
    * Fetch the next message from the underlying queue. If there are no messages, then `undefined`
    * should be returned.
    *
-   * @returns The message construct from the underlying transport, that inclues both the raw message envelope
+   * @returns The message construct from the underlying transport, that includes both the raw message envelope
    * plus the contents or body that contains the `@node-ts/bus-messages` message.
    */
   readNextMessage(): Promise<TransportMessage<TransportMessageType> | undefined>
@@ -81,7 +81,7 @@ export interface Transport<TransportMessageType = {}> {
    * trying to process a message.
    * @param message The message to be returned to the queue for reprocessing
    */
-  returnMessage(message: TransportMessage<TransportMessageType>): Promise<void>
+  returnMessage(message: TransportMessage<unknown>): Promise<void>
 
   /**
    * An optional function that is called before startup that will provide core dependencies

--- a/packages/bus-test/src/transport.integration.ts
+++ b/packages/bus-test/src/transport.integration.ts
@@ -78,7 +78,7 @@ export const transportTests = (
             topicIdentifier: systemMessageTopicIdentifier
           }
         )
-        .withHandler(handlerFor(TestFailMessage, async () => bus.fail()))
+        .withHandler(handlerFor(TestFailMessage, async () => bus.failMessage()))
         .withRetryStrategy({
           calculateRetryDelay(_: number): number {
             return RETRY_DELAY


### PR DESCRIPTION
Exposes `bus.returnMessage()` which immediately returns the message to the queue so it can be retried. 

This is an alternative to throwing an error, which sometimes is inaccurate and can represent an exception in the code rather than the developer just wanting to retry a message because a particular state isn't updated. 

An example of this could be a message that checks if a domain has been set up and propagated correctly throughout DNS servers. Whilst an error could be thrown to indicate that the domain is not ready, it's not useful to display errors in logs for this but rather return the message for retry and check later.