### PR TITLE
Receivers shouldn't delete messages

### DIFF
--- a/packages/bus-core/package.json
+++ b/packages/bus-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-ts/bus-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A service bus for message-based, distributed node applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/bus-core/src/message-lifecycle-context/message-lifecycle-context.ts
+++ b/packages/bus-core/src/message-lifecycle-context/message-lifecycle-context.ts
@@ -1,6 +1,10 @@
 import ALS from 'alscontext'
 
 type Context = {
+  /**
+   * Flags that the application has requested that the current message be
+   * returned to the queue for retry.
+   */
   messageReturnedToQueue: boolean
 }
 


### PR DESCRIPTION
When using a lambda/sqs integration, the bus is trying to delete the message when it processes successfully. This fails because the bus lib doesn't have a message object reference due to the message being passed to it using a receiver. 

Instead, on successful processing of a message the bus should simply return successfully and let the host delete the message

Similarly on error, the bus lib shouldn't attempt to return the message for retry, but instead rethrow any caught errors and let the host deal with returning the message to the queue for retry.