### PR TITLE
When auto provision bypass syncing attributes

### DIFF
--- a/packages/bus-sqs/src/sqs-transport.ts
+++ b/packages/bus-sqs/src/sqs-transport.ts
@@ -565,6 +565,14 @@ export class SqsTransport implements Transport<SQSMessage> {
     queueUrl: string,
     attributes?: Record<string, string>
   ): Promise<void> {
+    if (!this.autoProvision) {
+      this.logger.info(
+        'Bypass syncing queue attributes when autoProvision is disabled',
+        { queueUrl, attributes }
+      )
+      return
+    }
+
     // Check equality first to avoid potential API rate limit
     const existing = await this.sqs.send(
       new GetQueueAttributesCommand({


### PR DESCRIPTION
This is a follow up PR to https://github.com/node-ts/bus/pull/234 upon further testing I discovered that the library was trying to update queue attributes even when autoProvision is disabled for SQS transport.

This PR bypasses syncing queue attributes when auto provision is disabled. Below are some reasons why I think this change is needed.

 1. Separation of Concerns: When autoProvision is false, infrastructure management is intentionally delegated to external systems (Terraform, CloudFormation, etc.).
 2. Infrastructure as Code Conflicts: If queue attributes are managed by IaC tools, having the application sync attributes creates configuration drift. The application could override IaC-managed settings or vice versa, leading to unpredictable behavior.
3. Trust the Pre-Provisioned Configuration: When someone explicitly disables auto-provisioning, they're saying "I've already configured this correctly externally." The application should trust that configuration rather than try to "fix" it.

@adenhertog Happy to hear your thoughts on this.
